### PR TITLE
⚡ Spark: Smart Type Preservation & Worksheet Name Interpolation

### DIFF
--- a/.axioma/spark.md
+++ b/.axioma/spark.md
@@ -3,3 +3,7 @@
 ## 2025-05-15 - [XLSX Template Enhancements]
 **Learning:** Users often need to render simple lists or include row counters in their documents. Adding support for primitive arrays and special index markers significantly improves the library's versatility with minimal code changes.
 **Pattern:** Using special property paths (like `$index`, `$number`) is an effective way to expose metadata about the current iteration without cluttering the input data object.
+
+## 2025-05-16 - [Smart Type Preservation & Dynamic Metadata]
+**Learning:** Automatically preserving data types (like Dates and Numbers) when a cell contains only a marker is much more intuitive than forcing everything to strings. Also, interpolating worksheet names is a frequently requested feature for multi-sheet reports.
+**Pattern:** Detect "single-marker cells" using regex anchor patterns (`/^...$/`) to decide between direct value assignment (preserving type) and string replacement.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,8 @@ Agents should assume:
 ## Key Features
 
 - **Declarative Template Syntax**: Use `{{key}}` for single-value interpolation and `[[array.key]]` for repeating rows based on arrays.
+- **Smart Type Preservation**: Automatically preserves original data types (Number, Date, Boolean) when a cell contains only a single marker.
+- **Worksheet Name Interpolation**: Use `{{key}}` in worksheet names to generate dynamic sheet titles.
 - **Preserves Excel Formatting**: Keeps fonts, colors, borders, merges, and formulas from the original template when expanding rows.
 - **Conditional Rendering**: Automatically removes rows if the corresponding array is empty.
 - **Safe Missing Key Handling**: Leaves markers untouched if a data key is missing, allowing for easy debugging.
@@ -103,6 +105,7 @@ After interpolation with the data above, the result would be:
 ### 1. Single Value Interpolation: `{{key}}`
 
 - Used for static values that do not change per row.
+- **Type Preservation**: If the cell contains *only* the `{{key}}` marker, the resulting cell will have the same type as the data (e.g., Number, Date, Boolean).
 - Supports nested paths: `{{user.profile.email}}`.
 - If the key is missing, the marker remains in the cell as-is (e.g., `{{missing.key}}`).
 - If the value is `null` or `undefined`, the cell becomes empty (`""`).
@@ -110,10 +113,11 @@ After interpolation with the data above, the result would be:
 ### 2. Array-Based Row Repetition: `[[array.key]]` or `[[array]]`
 
 - Used inside a row to indicate that the entire row should be repeated for each item in the `array`.
+- **Type Preservation**: If a cell contains *only* a `[[ ]]` marker, it will preserve the original data type (e.g., Number, Date, Boolean).
 - The array name (`array`) must exist at the root of the data object and must be an array.
 - Each occurrence of `[[array.key]]` in the row is replaced with the value of `item.key` from the current iteration.
 - `[[array]]` (without property) is replaced by the item itself (useful for primitive arrays).
-- Special index markers are supported: `[[array.$index]]` (0-based), `[[array.$index1]]` or `[[array.$number]]` (1-based).
+- Special index markers are supported: `[[array.$index]]` (0-based), `[[array.$index1]]` or `[[array.$number]]` (1-based). These are returned as Numbers.
 - If the array is empty (`[]`), the row is removed from the output.
 - If `array` does not exist in the data, markers are left as-is.
 - If an item in the array does not have the specified key, the marker remains (e.g., `[[items.missing]]`).

--- a/packages/xlsx/src/index.ts
+++ b/packages/xlsx/src/index.ts
@@ -1,4 +1,5 @@
 import ExcelJS from 'exceljs';
+import { resolvePath } from '@interpolator/core';
 
 const { Workbook } = ExcelJS;
 
@@ -13,6 +14,13 @@ export async function interpolateXlsx(options: InterpolateXlsxOptions): Promise<
   await workbook.xlsx.load(template as any);
 
   for (const worksheet of workbook.worksheets) {
+    // Interpolate worksheet name
+    worksheet.name = worksheet.name.replace(/\{\{\s*([^\}]+)\s*\}\}/g, (_, path) => {
+      const { found, value: resolved } = resolvePath(data, path);
+      if (!found) return `{{${path}}}`;
+      return resolved == null ? '' : String(resolved);
+    });
+
     const rowsToExpand: { rowNumber: number; arrayKey: string }[] = [];
 
     worksheet.eachRow((row, rowNumber) => {
@@ -82,37 +90,70 @@ export async function interpolateXlsx(options: InterpolateXlsxOptions): Promise<
           if (value && typeof value === 'object' && 'formula' in value) {
             const originalFormula = (value as any).formula as string;
             const adjustedFormula = adjustFormulaForRow(originalFormula, rowNumber, newRowNumber);
-            newCell.value = {
+            value = {
               ...(value as any),
               formula: adjustedFormula
             };
             // Styles & validation will be copied below; skip marker interpolation for formulas
           } else if (typeof value === 'string') {
-            // Array interpolation: [[array.key]] or [[array]]
-            value = value.replace(/\[\[\s*([^\].\s]+)(?:\.([^\]\s]+))?\s*\]\]/g, (_, arrKey, propPath) => {
-              if (arrKey !== arrayKey) return propPath ? `[[${arrKey}.${propPath}]]` : `[[${arrKey}]]`;
-
-              if (!propPath) {
-                return item == null ? '' : String(item);
+            // Check if it's a single [[ ]] marker to preserve type
+            const singleArMatch = value.match(/^\[\[\s*([^\].\s]+)(?:\.([^\]\s]+))?\s*\]\]$/);
+            if (singleArMatch) {
+              const [, arrKey, propPath] = singleArMatch;
+              if (arrKey === arrayKey) {
+                if (!propPath) {
+                  value = item === undefined ? value : item;
+                } else if (propPath === '$index') {
+                  value = i;
+                } else if (propPath === '$index1' || propPath === '$number') {
+                  value = i + 1;
+                } else {
+                  const { found, value: resolved } = resolvePath(item, propPath);
+                  value = found ? resolved : value;
+                }
               }
+            }
 
-              if (propPath === '$index') return String(i);
-              if (propPath === '$index1' || propPath === '$number') return String(i + 1);
+            // If it was not a single array marker, or it's still a string, process all markers
+            if (typeof value === 'string') {
+              // Check if it's a single {{ }} marker to preserve type
+              const singleRootMatch = value.match(/^\{\{\s*([^\}]+)\s*\}\}$/);
+              if (singleRootMatch) {
+                const { found, value: resolved } = resolvePath(data, singleRootMatch[1]);
+                if (found) {
+                  value = resolved;
+                }
+              }
+            }
 
-              const { found, value: resolved } = resolvePath(item, propPath);
-              if (!found) return `[[${arrKey}.${propPath}]]`;
-              return resolved == null ? '' : String(resolved);
-            });
+            // Final string interpolation for remaining cases
+            if (typeof value === 'string') {
+              // Array interpolation: [[array.key]] or [[array]]
+              value = value.replace(/\[\[\s*([^\].\s]+)(?:\.([^\]\s]+))?\s*\]\]/g, (_, arrKey, propPath) => {
+                if (arrKey !== arrayKey) return propPath ? `[[${arrKey}.${propPath}]]` : `[[${arrKey}]]`;
 
-            // Root-level interpolation: {{key}}
-            value = value.replace(/\{\{\s*([^\}]+)\s*\}\}/g, (_, path) => {
-              const { found, value: resolved } = resolvePath(data, path);
-              if (!found) return `{{${path}}}`;
-              return resolved == null ? '' : String(resolved);
-            });
+                if (!propPath) {
+                  return item == null ? '' : String(item);
+                }
+
+                if (propPath === '$index') return String(i);
+                if (propPath === '$index1' || propPath === '$number') return String(i + 1);
+
+                const { found, value: resolved } = resolvePath(item, propPath);
+                if (!found) return `[[${arrKey}.${propPath}]]`;
+                return resolved == null ? '' : String(resolved);
+              });
+
+              // Root-level interpolation: {{key}}
+              value = value.replace(/\{\{\s*([^\}]+)\s*\}\}/g, (_, path) => {
+                const { found, value: resolved } = resolvePath(data, path);
+                if (!found) return `{{${path}}}`;
+                return resolved == null ? '' : String(resolved);
+              });
+            }
           }
 
-          if (typeof value !== 'undefined' && typeof value !== 'object') {
+          if (value !== undefined) {
             newCell.value = value;
           }
           // Preserve basic styles; merges will be handled separately in a later step
@@ -148,13 +189,24 @@ export async function interpolateXlsx(options: InterpolateXlsxOptions): Promise<
       row.eachCell((cell) => {
         if (typeof cell.value !== 'string') return;
 
-        let value = cell.value;
+        let value: any = cell.value;
 
-        value = value.replace(/\{\{\s*([^\}]+)\s*\}\}/g, (_, path) => {
-          const { found, value: resolved } = resolvePath(data, path);
-          if (!found) return `{{${path}}}`;
-          return resolved == null ? '' : String(resolved);
-        });
+        // Check if it's a single {{ }} marker to preserve type
+        const singleRootMatch = value.match(/^\{\{\s*([^\}]+)\s*\}\}$/);
+        if (singleRootMatch) {
+          const { found, value: resolved } = resolvePath(data, singleRootMatch[1]);
+          if (found) {
+            value = resolved;
+          }
+        }
+
+        if (typeof value === 'string') {
+          value = value.replace(/\{\{\s*([^\}]+)\s*\}\}/g, (_, path) => {
+            const { found, value: resolved } = resolvePath(data, path);
+            if (!found) return `{{${path}}}`;
+            return resolved == null ? '' : String(resolved);
+          });
+        }
 
         cell.value = value;
       });
@@ -163,24 +215,6 @@ export async function interpolateXlsx(options: InterpolateXlsxOptions): Promise<
 
   const result = await workbook.xlsx.writeBuffer();
   return result as any as Buffer;
-}
-
-// Reutilizar la función de core
-function resolvePath(obj: any, path: string): { found: boolean; value: any } {
-  const keys = path.split('.');
-  let current = obj;
-
-  for (const key of keys) {
-    if (current == null || typeof current !== 'object') {
-      return { found: false, value: undefined };
-    }
-    if (!(key in current)) {
-      return { found: false, value: undefined };
-    }
-    current = current[key];
-  }
-
-  return { found: true, value: current };
 }
 
 // Adjust row-relative references in formulas when cloning rows.

--- a/packages/xlsx/tests/functional.test.ts
+++ b/packages/xlsx/tests/functional.test.ts
@@ -376,15 +376,15 @@ describe('interpolateXlsx - functional', () => {
     const ws = await loadWorksheetFromResult(result, 'Sheet1');
 
     // Row 1
-    expect(ws.getCell('A1').value).toBe('0');
-    expect(ws.getCell('B1').value).toBe('1');
-    expect(ws.getCell('C1').value).toBe('1');
+    expect(ws.getCell('A1').value).toBe(0);
+    expect(ws.getCell('B1').value).toBe(1);
+    expect(ws.getCell('C1').value).toBe(1);
     expect(ws.getCell('D1').value).toBe('First');
 
     // Row 2
-    expect(ws.getCell('A2').value).toBe('1');
-    expect(ws.getCell('B2').value).toBe('2');
-    expect(ws.getCell('C2').value).toBe('2');
+    expect(ws.getCell('A2').value).toBe(1);
+    expect(ws.getCell('B2').value).toBe(2);
+    expect(ws.getCell('C2').value).toBe(2);
     expect(ws.getCell('D2').value).toBe('Second');
   });
 
@@ -403,5 +403,55 @@ describe('interpolateXlsx - functional', () => {
 
     expect(ws.getCell('A1').value).toBe('1. One');
     expect(ws.getCell('A2').value).toBe('2. Two');
+  });
+
+  it('should preserve type (number) for single {{}} markers', async () => {
+    const template = await buildTemplateBuffer((wb) => {
+      const ws = wb.addWorksheet('Sheet1');
+      ws.getCell('A1').value = '{{amount}}';
+    });
+
+    const data = { amount: 123.45 };
+
+    const result = await interpolateXlsx({ template, data });
+    const ws = await loadWorksheetFromResult(result, 'Sheet1');
+
+    expect(ws.getCell('A1').value).toBe(123.45);
+    expect(typeof ws.getCell('A1').value).toBe('number');
+  });
+
+  it('should preserve Date values in expanded rows', async () => {
+    const now = new Date();
+    // Normalize date to avoid ms differences if any during serialization
+    now.setMilliseconds(0);
+
+    const template = await buildTemplateBuffer((wb) => {
+      const ws = wb.addWorksheet('Sheet1');
+      ws.getCell('A1').value = 'Date';
+      ws.getCell('A2').value = now;
+      ws.getCell('B2').value = '[[items.id]]';
+    });
+
+    const data = { items: [{ id: 1 }] };
+    const result = await interpolateXlsx({ template, data });
+    const ws = await loadWorksheetFromResult(result, 'Sheet1');
+
+    const cellValue = ws.getCell('A2').value;
+    expect(cellValue).toBeInstanceOf(Date);
+    expect((cellValue as Date).getTime()).toBe(now.getTime());
+  });
+
+  it('should interpolate sheet names', async () => {
+    const template = await buildTemplateBuffer((wb) => {
+      wb.addWorksheet('Report {{year}}');
+    });
+
+    const data = { year: 2024 };
+    const result = await interpolateXlsx({ template, data });
+    const wb = new Workbook();
+    await wb.xlsx.load(result as any);
+
+    expect(wb.getWorksheet('Report 2024')).toBeDefined();
+    expect(wb.getWorksheet('Report {{year}}')).toBeUndefined();
   });
 });


### PR DESCRIPTION
💡 **What:** Added Smart Type Preservation for cells with single markers and enabled interpolation for worksheet names.
🎯 **Why:** To ensure numeric data stays numeric (summable) and dates stay dates in Excel, and to allow dynamic sheet titles.
📦 **What it adds:**
- Cells with only `{{key}}` or `[[array.key]]` preserve the original data type (Number, Date, Boolean).
- Worksheet names now support `{{key}}` interpolation.
- Fixed a bug where `Date` objects were not preserved during row expansion.
- Refactored `resolvePath` to use the core package implementation.
🚀 **How to use:**
- Set a cell value to `{{price}}` where `price` is a number; it remains a Number in Excel.
- Name a sheet `Report {{month}}`; it becomes "Report January".
♻️ **Deps Free:** No new dependencies added.
🎨 **Harmony:** Fits existing interpolation patterns and improves Excel data integrity.

---
*PR created automatically by Jules for task [1842515965386293536](https://jules.google.com/task/1842515965386293536) started by @galiprandi*