### PR TITLE
⚡ Spark: Enhanced Array Metadata Markers ($first, $last, $length)

### DIFF
--- a/.axioma/spark.md
+++ b/.axioma/spark.md
@@ -7,3 +7,7 @@
 ## 2025-05-16 - [Smart Type Preservation & Dynamic Metadata]
 **Learning:** Automatically preserving data types (like Dates and Numbers) when a cell contains only a marker is much more intuitive than forcing everything to strings. Also, interpolating worksheet names is a frequently requested feature for multi-sheet reports.
 **Pattern:** Detect "single-marker cells" using regex anchor patterns (`/^...$/`) to decide between direct value assignment (preserving type) and string replacement.
+
+## 2025-05-17 - [Enhanced Array Metadata]
+**Learning:** Providing boolean flags like `$first` and `$last` allows users to implement conditional formatting or separators without complex logic in the data source.
+**Pattern:** Extend existing metadata marker logic to support Booleans and array-level metrics (like `$length`) using the same path-based resolution pattern.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,7 +117,12 @@ After interpolation with the data above, the result would be:
 - The array name (`array`) must exist at the root of the data object and must be an array.
 - Each occurrence of `[[array.key]]` in the row is replaced with the value of `item.key` from the current iteration.
 - `[[array]]` (without property) is replaced by the item itself (useful for primitive arrays).
-- Special index markers are supported: `[[array.$index]]` (0-based), `[[array.$index1]]` or `[[array.$number]]` (1-based). These are returned as Numbers.
+- Special metadata markers are supported:
+  - `[[array.$index]]`: 0-based index (Number).
+  - `[[array.$index1]]` or `[[array.$number]]`: 1-based index (Number).
+  - `[[array.$first]]`: `true` for the first item, `false` otherwise (Boolean).
+  - `[[array.$last]]`: `true` for the last item, `false` otherwise (Boolean).
+  - `[[array.$length]]`: Total number of items in the array (Number).
 - If the array is empty (`[]`), the row is removed from the output.
 - If `array` does not exist in the data, markers are left as-is.
 - If an item in the array does not have the specified key, the marker remains (e.g., `[[items.missing]]`).

--- a/packages/xlsx/README.md
+++ b/packages/xlsx/README.md
@@ -111,8 +111,10 @@ You can use these special property paths within an array context to include indi
 
 - `[[array.$index]]`: The 0-based index of the current item (0, 1, 2, ...).
 - `[[array.$index1]]` or `[[array.$number]]`: The 1-based index of the current item (1, 2, 3, ...).
+- `[[array.$first]]` / `[[array.$last]]`: Boolean flags (`true`/`false`) for the first and last items.
+- `[[array.$length]]`: The total number of items in the array.
 
-Example: `[[items.$number]]. [[items.name]]` will produce "1. First Item", "2. Second Item", etc.
+Example: `[[items.$number]] of [[items.$length]]: [[items.name]]` will produce "1 of 10: First Item", etc.
 
 ## Formatting, formulas and merges
 

--- a/packages/xlsx/src/index.ts
+++ b/packages/xlsx/src/index.ts
@@ -107,6 +107,12 @@ export async function interpolateXlsx(options: InterpolateXlsxOptions): Promise<
                   value = i;
                 } else if (propPath === '$index1' || propPath === '$number') {
                   value = i + 1;
+                } else if (propPath === '$first') {
+                  value = i === 0;
+                } else if (propPath === '$last') {
+                  value = i === array.length - 1;
+                } else if (propPath === '$length') {
+                  value = array.length;
                 } else {
                   const { found, value: resolved } = resolvePath(item, propPath);
                   value = found ? resolved : value;
@@ -138,6 +144,9 @@ export async function interpolateXlsx(options: InterpolateXlsxOptions): Promise<
 
                 if (propPath === '$index') return String(i);
                 if (propPath === '$index1' || propPath === '$number') return String(i + 1);
+                if (propPath === '$first') return String(i === 0);
+                if (propPath === '$last') return String(i === array.length - 1);
+                if (propPath === '$length') return String(array.length);
 
                 const { found, value: resolved } = resolvePath(item, propPath);
                 if (!found) return `[[${arrKey}.${propPath}]]`;

--- a/packages/xlsx/tests/functional.test.ts
+++ b/packages/xlsx/tests/functional.test.ts
@@ -388,6 +388,48 @@ describe('interpolateXlsx - functional', () => {
     expect(ws.getCell('D2').value).toBe('Second');
   });
 
+  it('should support special metadata markers $first, $last, and $length', async () => {
+    const template = await buildTemplateBuffer((wb) => {
+      const ws = wb.addWorksheet('Sheet1');
+      ws.getCell('A1').value = '[[items.$first]]';
+      ws.getCell('B1').value = '[[items.$last]]';
+      ws.getCell('C1').value = '[[items.$length]]';
+    });
+
+    const data = {
+      items: [{ name: 'First' }, { name: 'Second' }],
+    };
+
+    const result = await interpolateXlsx({ template, data });
+    const ws = await loadWorksheetFromResult(result, 'Sheet1');
+
+    // Row 1
+    expect(ws.getCell('A1').value).toBe(true);
+    expect(ws.getCell('B1').value).toBe(false);
+    expect(ws.getCell('C1').value).toBe(2);
+
+    // Row 2
+    expect(ws.getCell('A2').value).toBe(false);
+    expect(ws.getCell('B2').value).toBe(true);
+    expect(ws.getCell('C2').value).toBe(2);
+  });
+
+  it('should support {{array.length}} as it is a property of the array', async () => {
+    const template = await buildTemplateBuffer((wb) => {
+      const ws = wb.addWorksheet('Sheet1');
+      ws.getCell('A1').value = 'Total items: {{items.length}}';
+    });
+
+    const data = {
+      items: [1, 2, 3],
+    };
+
+    const result = await interpolateXlsx({ template, data });
+    const ws = await loadWorksheetFromResult(result, 'Sheet1');
+
+    expect(ws.getCell('A1').value).toBe('Total items: 3');
+  });
+
   it('should combine primitive value and index in one row', async () => {
     const template = await buildTemplateBuffer((wb) => {
       const ws = wb.addWorksheet('Sheet1');


### PR DESCRIPTION
💡 **What:** Added `$first`, `$last`, and `$length` metadata markers for array expansion in the XLSX package.

🎯 **Why:** Users often need to perform conditional logic (like hiding separators on the last item) or display progress counters (e.g., "1 of 10") directly within the Excel template without modifying the input data.

📦 **What it adds:**
- `[[array.$first]]`: Returns `true` for the first item (Boolean).
- `[[array.$last]]`: Returns `true` for the last item (Boolean).
- `[[array.$length]]`: Returns the total number of items in the array (Number).

🚀 **How to use:**
In your template, use: `[[items.$number]] of [[items.$length]]: [[items.name]]`
Result: `1 of 5: My Item`

♻️ **Deps Free:** Verified. No new dependencies added to `package.json`.
🎨 **Harmony:** Extends the existing pattern established by `$index` and `$number`. Matches the Smart Type Preservation logic.

Tests added to `packages/xlsx/tests/functional.test.ts`.
Documentation updated in `AGENTS.md` and `packages/xlsx/README.md`.

---
*PR created automatically by Jules for task [8825838367032183860](https://jules.google.com/task/8825838367032183860) started by @galiprandi*