### PR TITLE
⚡ Spark: $even and $odd metadata markers

### DIFF
--- a/.axioma/spark.md
+++ b/.axioma/spark.md
@@ -11,3 +11,7 @@
 ## 2025-05-17 - [Enhanced Array Metadata]
 **Learning:** Providing boolean flags like `$first` and `$last` allows users to implement conditional formatting or separators without complex logic in the data source.
 **Pattern:** Extend existing metadata marker logic to support Booleans and array-level metrics (like `$length`) using the same path-based resolution pattern.
+
+## 2025-05-18 - [Styling and Conditional Markers]
+**Learning:** Adding `$even` and `$odd` markers makes it trivial for users to implement zebra-striping or alternating layouts in Excel without any preprocessing on the data side.
+**Pattern:** Always think of how metadata markers can replace manual data enrichment. If a value can be derived from the iteration context (like parity), it's a candidate for a metadata marker.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,8 @@ After interpolation with the data above, the result would be:
   - `[[array.$first]]`: `true` for the first item, `false` otherwise (Boolean).
   - `[[array.$last]]`: `true` for the last item, `false` otherwise (Boolean).
   - `[[array.$length]]`: Total number of items in the array (Number).
+  - `[[array.$even]]`: `true` for even-numbered rows (1-based), `false` otherwise (Boolean).
+  - `[[array.$odd]]`: `true` for odd-numbered rows (1-based), `false` otherwise (Boolean).
 - If the array is empty (`[]`), the row is removed from the output.
 - If `array` does not exist in the data, markers are left as-is.
 - If an item in the array does not have the specified key, the marker remains (e.g., `[[items.missing]]`).

--- a/packages/xlsx/src/index.ts
+++ b/packages/xlsx/src/index.ts
@@ -113,6 +113,10 @@ export async function interpolateXlsx(options: InterpolateXlsxOptions): Promise<
                   value = i === array.length - 1;
                 } else if (propPath === '$length') {
                   value = array.length;
+                } else if (propPath === '$even') {
+                  value = (i + 1) % 2 === 0;
+                } else if (propPath === '$odd') {
+                  value = (i + 1) % 2 !== 0;
                 } else {
                   const { found, value: resolved } = resolvePath(item, propPath);
                   value = found ? resolved : value;
@@ -147,6 +151,8 @@ export async function interpolateXlsx(options: InterpolateXlsxOptions): Promise<
                 if (propPath === '$first') return String(i === 0);
                 if (propPath === '$last') return String(i === array.length - 1);
                 if (propPath === '$length') return String(array.length);
+                if (propPath === '$even') return String((i + 1) % 2 === 0);
+                if (propPath === '$odd') return String((i + 1) % 2 !== 0);
 
                 const { found, value: resolved } = resolvePath(item, propPath);
                 if (!found) return `[[${arrKey}.${propPath}]]`;

--- a/packages/xlsx/tests/functional.test.ts
+++ b/packages/xlsx/tests/functional.test.ts
@@ -496,4 +496,30 @@ describe('interpolateXlsx - functional', () => {
     expect(wb.getWorksheet('Report 2024')).toBeDefined();
     expect(wb.getWorksheet('Report {{year}}')).toBeUndefined();
   });
+
+  it('should support $even and $odd metadata markers', async () => {
+    const template = await buildTemplateBuffer((wb) => {
+      const ws = wb.addWorksheet('Sheet1');
+      ws.getCell('A1').value = '[[items.$even]]';
+      ws.getCell('B1').value = '[[items.$odd]]';
+      ws.getCell('C1').value = 'Is even: [[items.$even]]';
+    });
+
+    const data = {
+      items: [{ name: 'First' }, { name: 'Second' }],
+    };
+
+    const result = await interpolateXlsx({ template, data });
+    const ws = await loadWorksheetFromResult(result, 'Sheet1');
+
+    // Row 1 (Index 0, Number 1 - Odd)
+    expect(ws.getCell('A1').value).toBe(false);
+    expect(ws.getCell('B1').value).toBe(true);
+    expect(ws.getCell('C1').value).toBe('Is even: false');
+
+    // Row 2 (Index 1, Number 2 - Even)
+    expect(ws.getCell('A2').value).toBe(true);
+    expect(ws.getCell('B2').value).toBe(false);
+    expect(ws.getCell('C2').value).toBe('Is even: true');
+  });
 });


### PR DESCRIPTION
💡 **What:** Added `$even` and `$odd` metadata markers for array interpolation in XLSX templates.
🎯 **Why:** Enables easy implementation of zebra-striping or alternating layouts in Excel documents without needing to enrich the input data object manually.
📦 **What it adds:**
- `[[array.$even]]`: Boolean `true` for even-numbered rows (1-based), `false` otherwise.
- `[[array.$odd]]`: Boolean `true` for odd-numbered rows (1-based), `false` otherwise.
🚀 **How to use:**
Use `[[items.$even]]` as a cell value to get a boolean, or inside a string like `"Row is [[items.$even]]"`.
♻️ **Deps Free:** No new dependencies added.
🎨 **Harmony:** Follows the established pattern of existing metadata markers like `$first`, `$last`, and `$index`.

---
*PR created automatically by Jules for task [16603432898982955626](https://jules.google.com/task/16603432898982955626) started by @galiprandi*