### PR TITLE
⚡ Spark: Excel Context Markers ($now, $row, $col, $sheet)

### DIFF
--- a/.axioma/spark.md
+++ b/.axioma/spark.md
@@ -15,3 +15,7 @@
 ## 2025-05-18 - [Styling and Conditional Markers]
 **Learning:** Adding `$even` and `$odd` markers makes it trivial for users to implement zebra-striping or alternating layouts in Excel without any preprocessing on the data side.
 **Pattern:** Always think of how metadata markers can replace manual data enrichment. If a value can be derived from the iteration context (like parity), it's a candidate for a metadata marker.
+
+## 2024-05-22 - Excel Context Markers
+**Learning:** Contextual information (, , , ) is frequently requested in document templates but often requires the user to manually enrich their data object. Providing these as built-in markers dramatically simplifies report generation templates.
+**Pattern:** Abstract path resolution into a context-aware helper that wraps the standard data resolution. This allows for clean injection of environment/runtime variables without polluting the user's data object.

--- a/packages/xlsx/src/index.ts
+++ b/packages/xlsx/src/index.ts
@@ -8,15 +8,37 @@ export interface InterpolateXlsxOptions {
   data: Record<string, any>;
 }
 
+/**
+ * Resolves a path from the data object or from the special Excel context markers.
+ */
+function resolveWithContext(
+  path: string,
+  data: any,
+  ctx: { now: Date; sheet?: string; row?: number; col?: number },
+): { found: boolean; value: any } {
+  const trimmedPath = path.trim();
+  if (trimmedPath === '$now') return { found: true, value: ctx.now };
+  if (trimmedPath === '$sheet') return { found: true, value: ctx.sheet };
+  if (trimmedPath === '$row') return { found: true, value: ctx.row };
+  if (trimmedPath === '$col') return { found: true, value: ctx.col };
+
+  return resolvePath(data, trimmedPath);
+}
+
 export async function interpolateXlsx(options: InterpolateXlsxOptions): Promise<Buffer> {
   const { template, data } = options;
   const workbook = new Workbook();
   await workbook.xlsx.load(template as any);
 
+  const now = new Date();
+
   for (const worksheet of workbook.worksheets) {
     // Interpolate worksheet name
     worksheet.name = worksheet.name.replace(/\{\{\s*([^\}]+)\s*\}\}/g, (_, path) => {
-      const { found, value: resolved } = resolvePath(data, path);
+      const { found, value: resolved } = resolveWithContext(path, data, {
+        now,
+        sheet: worksheet.name,
+      });
       if (!found) return `{{${path}}}`;
       return resolved == null ? '' : String(resolved);
     });
@@ -103,7 +125,7 @@ export async function interpolateXlsx(options: InterpolateXlsxOptions): Promise<
               if (arrKey === arrayKey) {
                 if (!propPath) {
                   value = item === undefined ? value : item;
-                } else if (propPath === '$index') {
+                } else if (propPath === '$index' || propPath === '$index0') {
                   value = i;
                 } else if (propPath === '$index1' || propPath === '$number') {
                   value = i + 1;
@@ -117,6 +139,10 @@ export async function interpolateXlsx(options: InterpolateXlsxOptions): Promise<
                   value = (i + 1) % 2 === 0;
                 } else if (propPath === '$odd') {
                   value = (i + 1) % 2 !== 0;
+                } else if (propPath === '$row') {
+                  value = newRowNumber;
+                } else if (propPath === '$col') {
+                  value = colNumber;
                 } else {
                   const { found, value: resolved } = resolvePath(item, propPath);
                   value = found ? resolved : value;
@@ -129,7 +155,12 @@ export async function interpolateXlsx(options: InterpolateXlsxOptions): Promise<
               // Check if it's a single {{ }} marker to preserve type
               const singleRootMatch = value.match(/^\{\{\s*([^\}]+)\s*\}\}$/);
               if (singleRootMatch) {
-                const { found, value: resolved } = resolvePath(data, singleRootMatch[1]);
+                const { found, value: resolved } = resolveWithContext(singleRootMatch[1], data, {
+                  now,
+                  sheet: worksheet.name,
+                  row: newRowNumber,
+                  col: colNumber,
+                });
                 if (found) {
                   value = resolved;
                 }
@@ -146,13 +177,15 @@ export async function interpolateXlsx(options: InterpolateXlsxOptions): Promise<
                   return item == null ? '' : String(item);
                 }
 
-                if (propPath === '$index') return String(i);
+                if (propPath === '$index' || propPath === '$index0') return String(i);
                 if (propPath === '$index1' || propPath === '$number') return String(i + 1);
                 if (propPath === '$first') return String(i === 0);
                 if (propPath === '$last') return String(i === array.length - 1);
                 if (propPath === '$length') return String(array.length);
                 if (propPath === '$even') return String((i + 1) % 2 === 0);
                 if (propPath === '$odd') return String((i + 1) % 2 !== 0);
+                if (propPath === '$row') return String(newRowNumber);
+                if (propPath === '$col') return String(colNumber);
 
                 const { found, value: resolved } = resolvePath(item, propPath);
                 if (!found) return `[[${arrKey}.${propPath}]]`;
@@ -161,7 +194,12 @@ export async function interpolateXlsx(options: InterpolateXlsxOptions): Promise<
 
               // Root-level interpolation: {{key}}
               value = value.replace(/\{\{\s*([^\}]+)\s*\}\}/g, (_, path) => {
-                const { found, value: resolved } = resolvePath(data, path);
+                const { found, value: resolved } = resolveWithContext(path, data, {
+                  now,
+                  sheet: worksheet.name,
+                  row: newRowNumber,
+                  col: colNumber,
+                });
                 if (!found) return `{{${path}}}`;
                 return resolved == null ? '' : String(resolved);
               });
@@ -200,8 +238,8 @@ export async function interpolateXlsx(options: InterpolateXlsxOptions): Promise<
     }
 
     // Second pass: interpolate root-level {{ }} markers in all cells
-    worksheet.eachRow((row) => {
-      row.eachCell((cell) => {
+    worksheet.eachRow((row, rowNumber) => {
+      row.eachCell((cell, colNumber) => {
         if (typeof cell.value !== 'string') return;
 
         let value: any = cell.value;
@@ -209,7 +247,12 @@ export async function interpolateXlsx(options: InterpolateXlsxOptions): Promise<
         // Check if it's a single {{ }} marker to preserve type
         const singleRootMatch = value.match(/^\{\{\s*([^\}]+)\s*\}\}$/);
         if (singleRootMatch) {
-          const { found, value: resolved } = resolvePath(data, singleRootMatch[1]);
+          const { found, value: resolved } = resolveWithContext(singleRootMatch[1], data, {
+            now,
+            sheet: worksheet.name,
+            row: rowNumber,
+            col: colNumber,
+          });
           if (found) {
             value = resolved;
           }
@@ -217,7 +260,12 @@ export async function interpolateXlsx(options: InterpolateXlsxOptions): Promise<
 
         if (typeof value === 'string') {
           value = value.replace(/\{\{\s*([^\}]+)\s*\}\}/g, (_, path) => {
-            const { found, value: resolved } = resolvePath(data, path);
+            const { found, value: resolved } = resolveWithContext(path, data, {
+              now,
+              sheet: worksheet.name,
+              row: rowNumber,
+              col: colNumber,
+            });
             if (!found) return `{{${path}}}`;
             return resolved == null ? '' : String(resolved);
           });

--- a/packages/xlsx/tests/functional.test.ts
+++ b/packages/xlsx/tests/functional.test.ts
@@ -522,4 +522,78 @@ describe('interpolateXlsx - functional', () => {
     expect(ws.getCell('B2').value).toBe(false);
     expect(ws.getCell('C2').value).toBe('Is even: true');
   });
+
+  describe('Excel context markers', () => {
+    it('should support {{$now}} for current date', async () => {
+      const template = await buildTemplateBuffer((wb) => {
+        const ws = wb.addWorksheet('Sheet1');
+        ws.getCell('A1').value = '{{$now}}';
+      });
+
+      const result = await interpolateXlsx({ template, data: {} });
+      const ws = await loadWorksheetFromResult(result, 'Sheet1');
+
+      const value = ws.getCell('A1').value;
+      expect(value).toBeInstanceOf(Date);
+      // It should be roughly now
+      expect(Math.abs((value as Date).getTime() - Date.now())).toBeLessThan(10000);
+    });
+
+    it('should support {{$sheet}}, {{$row}}, {{$col}} root markers', async () => {
+      const template = await buildTemplateBuffer((wb) => {
+        const ws = wb.addWorksheet('MySheet');
+        ws.getCell('A1').value = 'Sheet: {{$sheet}}';
+        ws.getCell('B2').value = '{{$row}}:{{$col}}';
+      });
+
+      const result = await interpolateXlsx({ template, data: {} });
+      const ws = await loadWorksheetFromResult(result, 'MySheet');
+
+      expect(ws.getCell('A1').value).toBe('Sheet: MySheet');
+      expect(ws.getCell('B2').value).toBe('2:2');
+    });
+
+    it('should support array expansion markers [[$row]], [[$col]], [[$index0]]', async () => {
+      const template = await buildTemplateBuffer((wb) => {
+        const ws = wb.addWorksheet('Sheet1');
+        ws.getCell('A1').value = '[[items.$index0]]';
+        ws.getCell('B1').value = '[[items.$row]]';
+        ws.getCell('C1').value = '[[items.$col]]';
+      });
+
+      const data = {
+        items: [{ name: 'A' }, { name: 'B' }],
+      };
+
+      const result = await interpolateXlsx({ template, data });
+      const ws = await loadWorksheetFromResult(result, 'Sheet1');
+
+      // Row 1
+      expect(ws.getCell('A1').value).toBe(0);
+      expect(ws.getCell('B1').value).toBe(1);
+      expect(ws.getCell('C1').value).toBe(3); // C is 3rd column
+
+      // Row 2
+      expect(ws.getCell('A2').value).toBe(1);
+      expect(ws.getCell('B2').value).toBe(2);
+      expect(ws.getCell('C2').value).toBe(3);
+    });
+
+    it('should support $row and $col in root interpolation within expanded rows', async () => {
+      const template = await buildTemplateBuffer((wb) => {
+        const ws = wb.addWorksheet('Sheet1');
+        ws.getCell('A1').value = 'Row {{ $row }} Col {{ $col }} for [[ items.name ]]';
+      });
+
+      const data = {
+        items: [{ name: 'A' }, { name: 'B' }],
+      };
+
+      const result = await interpolateXlsx({ template, data });
+      const ws = await loadWorksheetFromResult(result, 'Sheet1');
+
+      expect(ws.getCell('A1').value).toBe('Row 1 Col 1 for A');
+      expect(ws.getCell('A2').value).toBe('Row 2 Col 1 for B');
+    });
+  });
 });


### PR DESCRIPTION
💡 **What:** Added "Excel Context Markers" to the \`@interpolator/xlsx\` package.

🎯 **Why:** Users often need to include dynamic information like the generation date, worksheet name, or current row/column numbers in their reports without having to manually inject these values into their data object.

📦 **What it adds:**
- **\`\$now\`**: The current date and time.
- **\`\$sheet\`**: The current worksheet name.
- **\`\$row\` / \`\$col\`**: The current Excel row and column indices.
- **\`\$index0\`**: Alias for \`\$index\` (0-based) for better clarity in array expansions.
- Support for whitespace trimming in all markers (e.g., \`{{ user.name }}\` now works consistently).

🚀 **How to use:**
\`\`\`text
| Generated: {{\$now}} | Sheet: {{\$sheet}} |
| Row # | Item |
| [[items.\$row]] | [[items.name]] |
\`\`\`

♻️ **Deps Free:** Verified. Uses only built-in JS and existing utilities.
🎨 **Harmony:** Integrates seamlessly with existing "Smart Type Preservation" and array expansion logic. No breaking changes.

---
*PR created automatically by Jules for task [9687262231067184971](https://jules.google.com/task/9687262231067184971) started by @galiprandi*