### PR TITLE
⚡ Spark: Add Excel coordinate markers and metadata aliases

### DIFF
--- a/.axioma/spark.md
+++ b/.axioma/spark.md
@@ -16,6 +16,10 @@
 **Learning:** Adding `$even` and `$odd` markers makes it trivial for users to implement zebra-striping or alternating layouts in Excel without any preprocessing on the data side.
 **Pattern:** Always think of how metadata markers can replace manual data enrichment. If a value can be derived from the iteration context (like parity), it's a candidate for a metadata marker.
 
+## 2025-05-19 - [Excel Coordinate Markers]
+**Learning:** Providing markers that translate numeric indices into Excel coordinates (like `$colLetter` or `$cell`) bridges the gap between structured data and document layout. This allows users to create more dynamic references or labels within the template without needing to pre-calculate Excel-specific addresses in their data source.
+**Pattern:** Implement a robust utility for coordinate translation (e.g., column index to letter) and expose it through both global and iteration contexts to ensure consistency.
+
 ## 2024-05-22 - Excel Context Markers
 **Learning:** Contextual information (, , , ) is frequently requested in document templates but often requires the user to manually enrich their data object. Providing these as built-in markers dramatically simplifies report generation templates.
 **Pattern:** Abstract path resolution into a context-aware helper that wraps the standard data resolution. This allows for clean injection of environment/runtime variables without polluting the user's data object.

--- a/README.md
+++ b/README.md
@@ -92,9 +92,11 @@ Create a beautiful Excel invoice with your company branding. Use `{{client}}` fo
 Generate a single workbook where each sheet is named after a specific region or department using `{{department.name}}` in the tab title.
 
 ### Case 3: Data Exports with Counters
-Need a numbered list? Use the special index markers:
+Need a numbered list or cell references? Use the special metadata markers:
 - `[[items.$index]]`: 0, 1, 2...
 - `[[items.$number]]` or `[[items.$index1]]`: 1, 2, 3...
+- `{{$cell}}` or `[[items.$cell]]`: A1, B2, etc. (Current cell address)
+- `{{$colLetter}}` or `[[items.$colLetter]]`: A, B, AA, etc. (Current column letter)
 
 Example cell: `[[items.$number]]. [[items.name]]` produces "1. My Item".
 

--- a/packages/xlsx/README.md
+++ b/packages/xlsx/README.md
@@ -111,10 +111,28 @@ You can use these special property paths within an array context to include indi
 
 - `[[array.$index]]`: The 0-based index of the current item (0, 1, 2, ...).
 - `[[array.$index1]]` or `[[array.$number]]`: The 1-based index of the current item (1, 2, 3, ...).
-- `[[array.$first]]` / `[[array.$last]]`: Boolean flags (`true`/`false`) for the first and last items.
+- `[[array.$first]]` or `[[array.$isFirst]]`: Boolean flag (`true`/`false`) for the first item.
+- `[[array.$last]]` or `[[array.$isLast]]`: Boolean flag (`true`/`false`) for the last item.
+- `[[array.$even]]` or `[[array.$isEven]]`: Boolean flag (`true`/`false`) for even items (1-indexed).
+- `[[array.$odd]]` or `[[array.$isOdd]]`: Boolean flag (`true`/`false`) for odd items (1-indexed).
 - `[[array.$length]]`: The total number of items in the array.
+- `[[array.$cell]]`: The current cell address (e.g. A2, B3).
+- `[[array.$colLetter]]`: The current column letter (e.g. A, B, AA).
+- `[[array.$row]]`: The current row number.
+- `[[array.$col]]`: The current column number.
 
 Example: `[[items.$number]] of [[items.$length]]: [[items.name]]` will produce "1 of 10: First Item", etc.
+
+### Built-in context markers
+
+These markers can be used both in `{{}}` and `[[]]` contexts:
+
+- `{{$now}}`: Current date and time.
+- `{{$sheet}}`: Current worksheet name.
+- `{{$row}}`: Current row number.
+- `{{$col}}`: Current column number.
+- `{{$colLetter}}`: Current column letter (e.g. A, B, Z, AA).
+- `{{$cell}}`: Current cell address (e.g. A1, B2).
 
 ## Formatting, formulas and merges
 

--- a/packages/xlsx/src/index.ts
+++ b/packages/xlsx/src/index.ts
@@ -21,6 +21,13 @@ function resolveWithContext(
   if (trimmedPath === '$sheet') return { found: true, value: ctx.sheet };
   if (trimmedPath === '$row') return { found: true, value: ctx.row };
   if (trimmedPath === '$col') return { found: true, value: ctx.col };
+  if (trimmedPath === '$colLetter') return { found: true, value: ctx.col ? getColLetter(ctx.col) : undefined };
+  if (trimmedPath === '$cell') {
+    return {
+      found: true,
+      value: ctx.row && ctx.col ? `${getColLetter(ctx.col)}${ctx.row}` : undefined
+    };
+  }
 
   return resolvePath(data, trimmedPath);
 }
@@ -129,20 +136,24 @@ export async function interpolateXlsx(options: InterpolateXlsxOptions): Promise<
                   value = i;
                 } else if (propPath === '$index1' || propPath === '$number') {
                   value = i + 1;
-                } else if (propPath === '$first') {
+                } else if (propPath === '$first' || propPath === '$isFirst') {
                   value = i === 0;
-                } else if (propPath === '$last') {
+                } else if (propPath === '$last' || propPath === '$isLast') {
                   value = i === array.length - 1;
                 } else if (propPath === '$length') {
                   value = array.length;
-                } else if (propPath === '$even') {
+                } else if (propPath === '$even' || propPath === '$isEven') {
                   value = (i + 1) % 2 === 0;
-                } else if (propPath === '$odd') {
+                } else if (propPath === '$odd' || propPath === '$isOdd') {
                   value = (i + 1) % 2 !== 0;
                 } else if (propPath === '$row') {
                   value = newRowNumber;
                 } else if (propPath === '$col') {
                   value = colNumber;
+                } else if (propPath === '$colLetter') {
+                  value = getColLetter(colNumber);
+                } else if (propPath === '$cell') {
+                  value = `${getColLetter(colNumber)}${newRowNumber}`;
                 } else {
                   const { found, value: resolved } = resolvePath(item, propPath);
                   value = found ? resolved : value;
@@ -179,13 +190,15 @@ export async function interpolateXlsx(options: InterpolateXlsxOptions): Promise<
 
                 if (propPath === '$index' || propPath === '$index0') return String(i);
                 if (propPath === '$index1' || propPath === '$number') return String(i + 1);
-                if (propPath === '$first') return String(i === 0);
-                if (propPath === '$last') return String(i === array.length - 1);
+                if (propPath === '$first' || propPath === '$isFirst') return String(i === 0);
+                if (propPath === '$last' || propPath === '$isLast') return String(i === array.length - 1);
                 if (propPath === '$length') return String(array.length);
-                if (propPath === '$even') return String((i + 1) % 2 === 0);
-                if (propPath === '$odd') return String((i + 1) % 2 !== 0);
+                if (propPath === '$even' || propPath === '$isEven') return String((i + 1) % 2 === 0);
+                if (propPath === '$odd' || propPath === '$isOdd') return String((i + 1) % 2 !== 0);
                 if (propPath === '$row') return String(newRowNumber);
                 if (propPath === '$col') return String(colNumber);
+                if (propPath === '$colLetter') return getColLetter(colNumber);
+                if (propPath === '$cell') return `${getColLetter(colNumber)}${newRowNumber}`;
 
                 const { found, value: resolved } = resolvePath(item, propPath);
                 if (!found) return `[[${arrKey}.${propPath}]]`;
@@ -336,4 +349,15 @@ function parseCellRef(ref: string): { col: string; row: number } | null {
   const row = Number(rowStr);
   if (Number.isNaN(row)) return null;
   return { col, row };
+}
+
+function getColLetter(col: number): string {
+  let letter = '';
+  let n = col;
+  while (n > 0) {
+    const remainder = (n - 1) % 26;
+    letter = String.fromCharCode(65 + remainder) + letter;
+    n = Math.floor((n - 1) / 26);
+  }
+  return letter;
 }

--- a/packages/xlsx/tests/functional.test.ts
+++ b/packages/xlsx/tests/functional.test.ts
@@ -595,5 +595,58 @@ describe('interpolateXlsx - functional', () => {
       expect(ws.getCell('A1').value).toBe('Row 1 Col 1 for A');
       expect(ws.getCell('A2').value).toBe('Row 2 Col 1 for B');
     });
+
+    it('should support $colLetter and $cell markers', async () => {
+      const template = await buildTemplateBuffer((wb) => {
+        const ws = wb.addWorksheet('Sheet1');
+        ws.getCell('A1').value = 'Col: {{$colLetter}} Cell: {{$cell}}';
+        ws.getCell('Z1').value = '{{$colLetter}}';
+        ws.getCell('AA1').value = '{{$colLetter}}';
+        ws.getCell('A2').value = '[[items.name]] at [[items.$cell]] ([[items.$colLetter]])';
+      });
+
+      const data = {
+        items: [{ name: 'A' }, { name: 'B' }],
+      };
+
+      const result = await interpolateXlsx({ template, data });
+      const ws = await loadWorksheetFromResult(result, 'Sheet1');
+
+      expect(ws.getCell('A1').value).toBe('Col: A Cell: A1');
+      expect(ws.getCell('Z1').value).toBe('Z');
+      expect(ws.getCell('AA1').value).toBe('AA');
+
+      expect(ws.getCell('A2').value).toBe('A at A2 (A)');
+      expect(ws.getCell('A3').value).toBe('B at A3 (A)');
+    });
+
+    it('should support boolean aliases $isFirst, $isLast, $isEven, $isOdd', async () => {
+      const template = await buildTemplateBuffer((wb) => {
+        const ws = wb.addWorksheet('Sheet1');
+        ws.getCell('A1').value = '[[items.$isFirst]]';
+        ws.getCell('B1').value = '[[items.$isLast]]';
+        ws.getCell('C1').value = '[[items.$isEven]]';
+        ws.getCell('D1').value = '[[items.$isOdd]]';
+      });
+
+      const data = {
+        items: [{ name: 'A' }, { name: 'B' }],
+      };
+
+      const result = await interpolateXlsx({ template, data });
+      const ws = await loadWorksheetFromResult(result, 'Sheet1');
+
+      // Row 1
+      expect(ws.getCell('A1').value).toBe(true);
+      expect(ws.getCell('B1').value).toBe(false);
+      expect(ws.getCell('C1').value).toBe(false);
+      expect(ws.getCell('D1').value).toBe(true);
+
+      // Row 2
+      expect(ws.getCell('A2').value).toBe(false);
+      expect(ws.getCell('B2').value).toBe(true);
+      expect(ws.getCell('C2').value).toBe(true);
+      expect(ws.getCell('D2').value).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
💡 **What:** Added `$colLetter` and `$cell` metadata markers to XLSX interpolation. Also added `$isFirst`, `$isLast`, `$isEven`, and `$isOdd` as aliases for existing boolean markers.
🎯 **Why:** Users often need to reference specific Excel coordinates (like "A1" or "B") within their templates without manually enriching the data object. Aliases provide a more intuitive syntax for common boolean checks.
📦 **What it adds:**
- `{{$colLetter}}` / `[[items.$colLetter]]`: Current column letter (A, B, AA, etc.)
- `{{$cell}}` / `[[items.$cell]]`: Current cell address (A1, B2, etc.)
- `$isFirst`, `$isLast`, `$isEven`, `$isOdd` aliases for array expansion.
🚀 **How to use:**
`Cell A1: {{$colLetter}} produces "A"`
`Cell B2: {{$cell}} produces "B2"`
`[[items.name]] at [[items.$cell]]`
♻️ **Deps Free:** Confirmed, no new dependencies added.
🎨 **Harmony:** Fits perfectly with existing `$row`, `$col`, and `$index` marker patterns.

---
*PR created automatically by Jules for task [5821650362313401781](https://jules.google.com/task/5821650362313401781) started by @galiprandi*