### PR TITLE
⚡ Spark: add sheet metadata and root row parity markers

### DIFF
--- a/.axioma/spark.md
+++ b/.axioma/spark.md
@@ -23,3 +23,7 @@
 ## 2024-05-22 - Excel Context Markers
 **Learning:** Contextual information (, , , ) is frequently requested in document templates but often requires the user to manually enrich their data object. Providing these as built-in markers dramatically simplifies report generation templates.
 **Pattern:** Abstract path resolution into a context-aware helper that wraps the standard data resolution. This allows for clean injection of environment/runtime variables without polluting the user's data object.
+
+## 2026-05-29 - [Sheet Metadata and Root Context Consistency]
+**Learning:** Exposing workbook-level metadata (like sheet count and position) allows for more professional, context-aware reports (e.g., "Sheet 1 of 5"). Aligning root context markers with iteration markers (like parity) creates a more predictable API for users.
+**Pattern:** Ensure all available document hierarchy metadata is injectable into the resolution context. Consistency between global markers and loop-local markers reduces cognitive load for template authors.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,11 +120,11 @@ After interpolation with the data above, the result would be:
 - Special metadata markers are supported:
   - `[[array.$index]]`: 0-based index (Number).
   - `[[array.$index1]]` or `[[array.$number]]`: 1-based index (Number).
-  - `[[array.$first]]`: `true` for the first item, `false` otherwise (Boolean).
-  - `[[array.$last]]`: `true` for the last item, `false` otherwise (Boolean).
-  - `[[array.$length]]`: Total number of items in the array (Number).
-  - `[[array.$even]]`: `true` for even-numbered rows (1-based), `false` otherwise (Boolean).
-  - `[[array.$odd]]`: `true` for odd-numbered rows (1-based), `false` otherwise (Boolean).
+  - `[[array.$first]]` or `[[array.$isFirst]]`: `true` for the first item.
+  - `[[array.$last]]` or `[[array.$isLast]]`: `true` for the last item.
+  - `[[array.$length]]`: Total number of items in the array.
+  - `[[array.$even]]` or `[[array.$isEven]]`: `true` for even-numbered rows.
+  - `[[array.$odd]]` or `[[array.$isOdd]]`: `true` for odd-numbered rows.
 - If the array is empty (`[]`), the row is removed from the output.
 - If `array` does not exist in the data, markers are left as-is.
 - If an item in the array does not have the specified key, the marker remains (e.g., `[[items.missing]]`).

--- a/packages/xlsx/README.md
+++ b/packages/xlsx/README.md
@@ -128,9 +128,16 @@ Example: `[[items.$number]] of [[items.$length]]: [[items.name]]` will produce "
 These markers can be used both in `{{}}` and `[[]]` contexts:
 
 - `{{$now}}`: Current date and time.
-- `{{$sheet}}`: Current worksheet name.
+- `{{$sheet}}` or `{{$sheetName}}`: Current worksheet name.
+- `{{$sheetIndex}}`: 0-based worksheet index.
+- `{{$sheetNumber}}`: 1-based worksheet index.
+- `{{$totalSheets}}`: Total number of sheets in the workbook.
+- `{{$isFirstSheet}}`: `true` for the first sheet.
+- `{{$isLastSheet}}`: `true` for the last sheet.
 - `{{$row}}`: Current row number.
 - `{{$col}}`: Current column number.
+- `{{$isEven}}`: `true` for even-numbered rows.
+- `{{$isOdd}}`: `true` for odd-numbered rows.
 - `{{$colLetter}}`: Current column letter (e.g. A, B, Z, AA).
 - `{{$cell}}`: Current cell address (e.g. A1, B2).
 

--- a/packages/xlsx/src/index.ts
+++ b/packages/xlsx/src/index.ts
@@ -14,18 +14,44 @@ export interface InterpolateXlsxOptions {
 function resolveWithContext(
   path: string,
   data: any,
-  ctx: { now: Date; sheet?: string; row?: number; col?: number },
+  ctx: {
+    now: Date;
+    sheet?: string;
+    sheetIndex?: number;
+    totalSheets?: number;
+    row?: number;
+    col?: number;
+  },
 ): { found: boolean; value: any } {
   const trimmedPath = path.trim();
   if (trimmedPath === '$now') return { found: true, value: ctx.now };
-  if (trimmedPath === '$sheet') return { found: true, value: ctx.sheet };
+  if (trimmedPath === '$sheet' || trimmedPath === '$sheetName') return { found: true, value: ctx.sheet };
+  if (trimmedPath === '$sheetIndex') return { found: true, value: ctx.sheetIndex };
+  if (trimmedPath === '$sheetNumber')
+    return { found: true, value: ctx.sheetIndex !== undefined ? ctx.sheetIndex + 1 : undefined };
+  if (trimmedPath === '$totalSheets') return { found: true, value: ctx.totalSheets };
+  if (trimmedPath === '$isFirstSheet' || trimmedPath === '$isFirst')
+    return { found: true, value: ctx.sheetIndex === 0 };
+  if (trimmedPath === '$isLastSheet' || trimmedPath === '$isLast') {
+    return {
+      found: true,
+      value:
+        ctx.sheetIndex !== undefined && ctx.totalSheets !== undefined
+          ? ctx.sheetIndex === ctx.totalSheets - 1
+          : undefined,
+    };
+  }
   if (trimmedPath === '$row') return { found: true, value: ctx.row };
   if (trimmedPath === '$col') return { found: true, value: ctx.col };
+  if (trimmedPath === '$isEven' || trimmedPath === '$even')
+    return { found: true, value: ctx.row !== undefined ? ctx.row % 2 === 0 : undefined };
+  if (trimmedPath === '$isOdd' || trimmedPath === '$odd')
+    return { found: true, value: ctx.row !== undefined ? ctx.row % 2 !== 0 : undefined };
   if (trimmedPath === '$colLetter') return { found: true, value: ctx.col ? getColLetter(ctx.col) : undefined };
   if (trimmedPath === '$cell') {
     return {
       found: true,
-      value: ctx.row && ctx.col ? `${getColLetter(ctx.col)}${ctx.row}` : undefined
+      value: ctx.row && ctx.col ? `${getColLetter(ctx.col)}${ctx.row}` : undefined,
     };
   }
 
@@ -38,17 +64,18 @@ export async function interpolateXlsx(options: InterpolateXlsxOptions): Promise<
   await workbook.xlsx.load(template as any);
 
   const now = new Date();
+  const totalSheets = workbook.worksheets.length;
 
-  for (const worksheet of workbook.worksheets) {
+  for (let sIdx = 0; sIdx < totalSheets; sIdx++) {
+    const worksheet = workbook.worksheets[sIdx];
+    const sheetCtx = { now, sheet: worksheet.name, sheetIndex: sIdx, totalSheets };
     // Interpolate worksheet name
     worksheet.name = worksheet.name.replace(/\{\{\s*([^\}]+)\s*\}\}/g, (_, path) => {
-      const { found, value: resolved } = resolveWithContext(path, data, {
-        now,
-        sheet: worksheet.name,
-      });
+      const { found, value: resolved } = resolveWithContext(path, data, sheetCtx);
       if (!found) return `{{${path}}}`;
       return resolved == null ? '' : String(resolved);
     });
+    sheetCtx.sheet = worksheet.name;
 
     const rowsToExpand: { rowNumber: number; arrayKey: string }[] = [];
 
@@ -167,8 +194,7 @@ export async function interpolateXlsx(options: InterpolateXlsxOptions): Promise<
               const singleRootMatch = value.match(/^\{\{\s*([^\}]+)\s*\}\}$/);
               if (singleRootMatch) {
                 const { found, value: resolved } = resolveWithContext(singleRootMatch[1], data, {
-                  now,
-                  sheet: worksheet.name,
+                  ...sheetCtx,
                   row: newRowNumber,
                   col: colNumber,
                 });
@@ -208,8 +234,7 @@ export async function interpolateXlsx(options: InterpolateXlsxOptions): Promise<
               // Root-level interpolation: {{key}}
               value = value.replace(/\{\{\s*([^\}]+)\s*\}\}/g, (_, path) => {
                 const { found, value: resolved } = resolveWithContext(path, data, {
-                  now,
-                  sheet: worksheet.name,
+                  ...sheetCtx,
                   row: newRowNumber,
                   col: colNumber,
                 });
@@ -261,8 +286,7 @@ export async function interpolateXlsx(options: InterpolateXlsxOptions): Promise<
         const singleRootMatch = value.match(/^\{\{\s*([^\}]+)\s*\}\}$/);
         if (singleRootMatch) {
           const { found, value: resolved } = resolveWithContext(singleRootMatch[1], data, {
-            now,
-            sheet: worksheet.name,
+            ...sheetCtx,
             row: rowNumber,
             col: colNumber,
           });
@@ -274,8 +298,7 @@ export async function interpolateXlsx(options: InterpolateXlsxOptions): Promise<
         if (typeof value === 'string') {
           value = value.replace(/\{\{\s*([^\}]+)\s*\}\}/g, (_, path) => {
             const { found, value: resolved } = resolveWithContext(path, data, {
-              now,
-              sheet: worksheet.name,
+              ...sheetCtx,
               row: rowNumber,
               col: colNumber,
             });

--- a/packages/xlsx/tests/functional.test.ts
+++ b/packages/xlsx/tests/functional.test.ts
@@ -620,6 +620,46 @@ describe('interpolateXlsx - functional', () => {
       expect(ws.getCell('A3').value).toBe('B at A3 (A)');
     });
 
+    it('should support sheet metadata markers', async () => {
+      const template = await buildTemplateBuffer((wb) => {
+        const ws1 = wb.addWorksheet('First');
+        ws1.getCell('A1').value = 'Sheet {{$sheetNumber}} of {{$totalSheets}} (Index: {{$sheetIndex}})';
+        ws1.getCell('A2').value = 'First: {{$isFirstSheet}}, Last: {{$isLastSheet}}';
+        ws1.getCell('A3').value = 'Name: {{$sheetName}}';
+
+        const ws2 = wb.addWorksheet('Second');
+        ws2.getCell('A1').value = 'Sheet {{$sheetNumber}} of {{$totalSheets}}';
+        ws2.getCell('A2').value = 'First: {{$isFirstSheet}}, Last: {{$isLastSheet}}';
+      });
+
+      const result = await interpolateXlsx({ template, data: {} });
+      const wb = new Workbook();
+      await wb.xlsx.load(result as any);
+
+      const ws1 = wb.getWorksheet('First')!;
+      expect(ws1.getCell('A1').value).toBe('Sheet 1 of 2 (Index: 0)');
+      expect(ws1.getCell('A2').value).toBe('First: true, Last: false');
+      expect(ws1.getCell('A3').value).toBe('Name: First');
+
+      const ws2 = wb.getWorksheet('Second')!;
+      expect(ws2.getCell('A1').value).toBe('Sheet 2 of 2');
+      expect(ws2.getCell('A2').value).toBe('First: false, Last: true');
+    });
+
+    it('should support root row parity markers $isEven and $isOdd', async () => {
+      const template = await buildTemplateBuffer((wb) => {
+        const ws = wb.addWorksheet('Sheet1');
+        ws.getCell('A1').value = 'Row 1: {{$isEven}}/{{$isOdd}}';
+        ws.getCell('A2').value = 'Row 2: {{$isEven}}/{{$isOdd}}';
+      });
+
+      const result = await interpolateXlsx({ template, data: {} });
+      const ws = await loadWorksheetFromResult(result, 'Sheet1');
+
+      expect(ws.getCell('A1').value).toBe('Row 1: false/true');
+      expect(ws.getCell('A2').value).toBe('Row 2: true/false');
+    });
+
     it('should support boolean aliases $isFirst, $isLast, $isEven, $isOdd', async () => {
       const template = await buildTemplateBuffer((wb) => {
         const ws = wb.addWorksheet('Sheet1');


### PR DESCRIPTION
💡 **What:** Added sheet-level metadata markers and root-level row parity markers to `@interpolator/xlsx`.
🎯 **Why:** Users need to generate reports with context like "Sheet 1 of 5" or apply conditional-like logic (e.g., zebra striping) at the root level.
📦 **What it adds:**
  - `{{$sheetName}}`, `{{$sheetIndex}}`, `{{$sheetNumber}}`, `{{$totalSheets}}`, `{{$isFirstSheet}}`, `{{$isLastSheet}}`.
  - `{{$isEven}}`, `{{$isOdd}}`, `{{$even}}`, `{{$odd}}`.
🚀 **How to use:** Use `{{$sheetNumber}} of {{$totalSheets}}` in any cell to show progress.
♻️ **Deps Free:** Confirmed, only uses existing `exceljs` and core logic.
🎨 **Harmony:** Follows the existing `$marker` pattern used for array expansion.

---
*PR created automatically by Jules for task [3066099850031321472](https://jules.google.com/task/3066099850031321472) started by @galiprandi*