### PR TITLE
⚡ Spark: Piped Transformations for Template Markers

### DIFF
--- a/.axioma/spark.md
+++ b/.axioma/spark.md
@@ -39,3 +39,7 @@
 ## 2026-06-15 - [Centralized Marker Resolution and Advanced Context]
 **Learning:** Consolidating marker resolution into a single context-aware function ('resolveInternal') significantly simplifies the interpolation engine. It allows for consistent behavior between root-level and array-level markers, and makes it trivial to add new metadata markers like $hour or $isHeader.
 **Pattern:** Pass a rich 'context' object (containing sheet, row, col, index, length, etc.) through the resolution chain to enable powerful, context-sensitive markers without complicating the user's data schema.
+
+## 2026-05-31 - [Piped Transformations for Template Markers]
+**Learning:** Adding a pipe operator (`|`) for string transformations (upper, lower, capitalize, trim, camelCase) provides users with powerful formatting capabilities directly in the template, reducing the need for data preprocessing. Chaining these transforms increases flexibility.
+**Pattern:** Decouple path resolution from value transformation. Resolve the value first, then apply a series of transformations. This allows the same transformation logic to be reused across different marker types (interpolation and array expansion) and data sources (main data and fallbacks).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,7 @@ After interpolation with the data above, the result would be:
 - **Type Preservation**: If the cell contains *only* the `{{key}}` marker, the resulting cell will have the same type as the data (e.g., Number, Date, Boolean).
 - Supports nested paths: `{{user.profile.email}}`.
 - **Default values**: `{{path || fallback}}`. Fallback can be a literal string or another path.
+- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`, `lower`, `capitalize`, `trim`, `camelCase`. You can chain them: `{{title | trim | capitalize}}`.
 - If the key is missing and no default is provided, the marker remains in the cell as-is.
 - If the value is `null` or `undefined` and no default is provided, the cell becomes empty (`""`).
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Used for static values that appear once in your document (e.g., a customer name,
 - **Nested Paths**: Supports dot notation like `{{user.profile.name}}`.
 - **Missing Data**: If a key is missing, the marker `{{key}}` stays in the cell for easier debugging.
 - **Null Values**: If a value is `null` or `undefined`, the cell is cleared.
+- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`, `lower`, `capitalize`, `trim`, `camelCase`. You can chain them: `{{title | trim | capitalize}}`.
 
 #### Array-Based Row Expansion: `[[array.key]]`
 Used to repeat an entire row for every item in an array.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,3 +35,34 @@ export function resolvePath(obj: any, path: string): { found: boolean; value: an
 
   return { found: true, value: current };
 }
+
+export function applyTransforms(value: any, transforms: string[]): any {
+  if (value == null || typeof value !== 'string') return value;
+
+  let result = value;
+  for (const t of transforms) {
+    const transform = t.trim().toLowerCase();
+    switch (transform) {
+      case 'upper':
+        result = result.toUpperCase();
+        break;
+      case 'lower':
+        result = result.toLowerCase();
+        break;
+      case 'capitalize':
+        result = result.charAt(0).toUpperCase() + result.slice(1);
+        break;
+      case 'trim':
+        result = result.trim();
+        break;
+      case 'camelcase':
+        result = result
+          .trim()
+          .replace(/[^a-zA-Z0-9]+(.)/g, (_, chr) => chr.toUpperCase())
+          .replace(/[^a-zA-Z0-9]+$/, '')
+          .replace(/^[A-Z]/, (chr) => chr.toLowerCase());
+        break;
+    }
+  }
+  return result;
+}

--- a/packages/xlsx/src/index.ts
+++ b/packages/xlsx/src/index.ts
@@ -1,5 +1,5 @@
 import ExcelJS from 'exceljs';
-import { resolvePath } from '@interpolator/core';
+import { resolvePath, applyTransforms } from '@interpolator/core';
 
 const { Workbook } = ExcelJS;
 
@@ -27,15 +27,23 @@ function resolveWithContext(
 ): { found: boolean; value: any } {
   const trimmed = path.trim();
   const parts = trimmed.split(/\s*\|\|\s*/);
-  const mainPath = parts[0];
+  const mainPathWithTransforms = parts[0];
   const defaultValue = parts[1];
+
+  const [mainPath, ...transforms] = mainPathWithTransforms.split(/\s*\|\s*/);
 
   let result = resolveInternal(mainPath, data, ctx);
 
   if ((!result.found || result.value == null) && defaultValue !== undefined) {
     // Try to resolve default value as a path first, if not found, use as literal
-    const resolvedDefault = resolveInternal(defaultValue, data, ctx);
-    return { found: true, value: resolvedDefault.found ? resolvedDefault.value : defaultValue };
+    const [defaultPath, ...defaultTransforms] = defaultValue.split(/\s*\|\s*/);
+    const resolvedDefault = resolveInternal(defaultPath, data, ctx);
+    const value = resolvedDefault.found ? resolvedDefault.value : defaultPath;
+    return { found: true, value: applyTransforms(value, defaultTransforms) };
+  }
+
+  if (result.found && transforms.length > 0) {
+    result.value = applyTransforms(result.value, transforms);
   }
 
   return result;

--- a/packages/xlsx/tests/functional.test.ts
+++ b/packages/xlsx/tests/functional.test.ts
@@ -844,5 +844,62 @@ describe('interpolateXlsx - functional', () => {
       expect(ws.getCell('A1').value).toBe('Row 1: A (1 of 2)');
       expect(ws.getCell('A2').value).toBe('Row 2: B (2 of 2)');
     });
+
+    it('should support transformations with pipe operator', async () => {
+      const template = await buildTemplateBuffer((wb) => {
+        const ws = wb.addWorksheet('Sheet1');
+        ws.getCell('A1').value = '{{name | upper}}';
+        ws.getCell('A2').value = '{{name | lower}}';
+        ws.getCell('A3').value = '{{name | capitalize}}';
+        ws.getCell('A4').value = '{{phrase | trim}}';
+        ws.getCell('A5').value = '{{phrase | camelCase}}';
+        ws.getCell('A6').value = '{{missing | upper || Default Value | upper}}';
+      });
+
+      const data = {
+        name: 'spark',
+        phrase: '  hello world  ',
+      };
+
+      const result = await interpolateXlsx({ template, data });
+      const ws = await loadWorksheetFromResult(result, 'Sheet1');
+
+      expect(ws.getCell('A1').value).toBe('SPARK');
+      expect(ws.getCell('A2').value).toBe('spark');
+      expect(ws.getCell('A3').value).toBe('Spark');
+      expect(ws.getCell('A4').value).toBe('hello world');
+      expect(ws.getCell('A5').value).toBe('helloWorld');
+      expect(ws.getCell('A6').value).toBe('DEFAULT VALUE');
+    });
+
+    it('should support multiple transformations chained with pipes', async () => {
+      const template = await buildTemplateBuffer((wb) => {
+        const ws = wb.addWorksheet('Sheet1');
+        ws.getCell('A1').value = '{{phrase | trim | upper}}';
+      });
+
+      const data = { phrase: '  spark  ' };
+      const result = await interpolateXlsx({ template, data });
+      const ws = await loadWorksheetFromResult(result, 'Sheet1');
+
+      expect(ws.getCell('A1').value).toBe('SPARK');
+    });
+
+    it('should support transformations in array expansion', async () => {
+      const template = await buildTemplateBuffer((wb) => {
+        const ws = wb.addWorksheet('Sheet1');
+        ws.getCell('A1').value = '[[items.name | upper]]';
+      });
+
+      const data = {
+        items: [{ name: 'spark' }, { name: 'agent' }],
+      };
+
+      const result = await interpolateXlsx({ template, data });
+      const ws = await loadWorksheetFromResult(result, 'Sheet1');
+
+      expect(ws.getCell('A1').value).toBe('SPARK');
+      expect(ws.getCell('A2').value).toBe('AGENT');
+    });
   });
 });


### PR DESCRIPTION
💡 **What:** Added a pipe operator (`|`) to template markers to support on-the-fly string transformations.
🎯 **Why:** Users often need simple formatting (e.g., uppercase, capitalization, camelCase) without having to preprocess their data before interpolation.
📦 **What it adds:** 
  - New syntax: `{{name | upper}}`, `[[items.name | capitalize || Guest]]`.
  - Supported transforms: `upper`, `lower`, `capitalize`, `trim`, `camelCase`.
  - Support for chaining: `{{title | trim | upper}}`.
🚀 **How to use:** Simply add `| <transform>` after the path in your `{{}}` or `[[]]` markers.
♻️ **Deps Free:** Uses only built-in JavaScript string methods.
🎨 **Harmony:** Integrates seamlessly with existing path resolution and default value logic.

---
*PR created automatically by Jules for task [5438652240521202665](https://jules.google.com/task/5438652240521202665) started by @galiprandi*