### PR TITLE
⚡ Spark: New string transformations (pascalCase, snakeCase, kebabCase)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ After interpolation with the data above, the result would be:
 - **Type Preservation**: If the cell contains *only* the `{{key}}` marker, the resulting cell will have the same type as the data (e.g., Number, Date, Boolean).
 - Supports nested paths: `{{user.profile.email}}`.
 - **Default values**: `{{path || fallback}}`. Fallback can be a literal string or another path.
-- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`, `lower`, `capitalize`, `trim`, `camelCase`. You can chain them: `{{title | trim | capitalize}}`.
+- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`/`uppercase`, `lower`/`lowercase`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`. You can chain them: `{{title | trim | capitalize}}`.
 - If the key is missing and no default is provided, the marker remains in the cell as-is.
 - If the value is `null` or `undefined` and no default is provided, the cell becomes empty (`""`).
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -44,9 +44,11 @@ export function applyTransforms(value: any, transforms: string[]): any {
     const transform = t.trim().toLowerCase();
     switch (transform) {
       case 'upper':
+      case 'uppercase':
         result = result.toUpperCase();
         break;
       case 'lower':
+      case 'lowercase':
         result = result.toLowerCase();
         break;
       case 'capitalize':
@@ -61,6 +63,29 @@ export function applyTransforms(value: any, transforms: string[]): any {
           .replace(/[^a-zA-Z0-9]+(.)/g, (_, chr) => chr.toUpperCase())
           .replace(/[^a-zA-Z0-9]+$/, '')
           .replace(/^[A-Z]/, (chr) => chr.toLowerCase());
+        break;
+      case 'pascalcase':
+        result = result
+          .trim()
+          .replace(/[^a-zA-Z0-9]+(.)/g, (_, chr) => chr.toUpperCase())
+          .replace(/[^a-zA-Z0-9]+$/, '')
+          .replace(/^[a-z]/, (chr) => chr.toUpperCase());
+        break;
+      case 'snakecase':
+        result = result
+          .trim()
+          .replace(/([a-z])([A-Z])/g, '$1_$2')
+          .replace(/[^a-zA-Z0-9]+/g, '_')
+          .toLowerCase()
+          .replace(/^_+|_+$/g, '');
+        break;
+      case 'kebabcase':
+        result = result
+          .trim()
+          .replace(/([a-z])([A-Z])/g, '$1-$2')
+          .replace(/[^a-zA-Z0-9]+/g, '-')
+          .toLowerCase()
+          .replace(/^-+|-+$/g, '');
         break;
     }
   }

--- a/packages/core/tests/index.test.ts
+++ b/packages/core/tests/index.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { applyTransforms } from '../src/index';
+
+describe('applyTransforms', () => {
+  it('should handle upper and uppercase', () => {
+    expect(applyTransforms('hello', ['upper'])).toBe('HELLO');
+    expect(applyTransforms('hello', ['uppercase'])).toBe('HELLO');
+  });
+
+  it('should handle lower and lowercase', () => {
+    expect(applyTransforms('HELLO', ['lower'])).toBe('hello');
+    expect(applyTransforms('HELLO', ['lowercase'])).toBe('hello');
+  });
+
+  it('should handle capitalize', () => {
+    expect(applyTransforms('hello', ['capitalize'])).toBe('Hello');
+  });
+
+  it('should handle trim', () => {
+    expect(applyTransforms('  hello  ', ['trim'])).toBe('hello');
+  });
+
+  it('should handle camelcase', () => {
+    expect(applyTransforms('hello world', ['camelcase'])).toBe('helloWorld');
+    expect(applyTransforms('Hello World', ['camelcase'])).toBe('helloWorld');
+    expect(applyTransforms('hello-world', ['camelcase'])).toBe('helloWorld');
+    expect(applyTransforms('hello_world', ['camelcase'])).toBe('helloWorld');
+  });
+
+  it('should handle pascalcase', () => {
+    expect(applyTransforms('hello world', ['pascalcase'])).toBe('HelloWorld');
+    expect(applyTransforms('hello-world', ['pascalcase'])).toBe('HelloWorld');
+    expect(applyTransforms('hello_world', ['pascalcase'])).toBe('HelloWorld');
+  });
+
+  it('should handle snakecase', () => {
+    expect(applyTransforms('helloWorld', ['snakecase'])).toBe('hello_world');
+    expect(applyTransforms('hello world', ['snakecase'])).toBe('hello_world');
+    expect(applyTransforms('hello-world', ['snakecase'])).toBe('hello_world');
+  });
+
+  it('should handle kebabcase', () => {
+    expect(applyTransforms('helloWorld', ['kebabcase'])).toBe('hello-world');
+    expect(applyTransforms('hello world', ['kebabcase'])).toBe('hello-world');
+    expect(applyTransforms('hello_world', ['kebabcase'])).toBe('hello-world');
+  });
+
+  it('should handle chained transformations', () => {
+    expect(applyTransforms('  hello world  ', ['trim', 'camelcase', 'capitalize'])).toBe('HelloWorld');
+  });
+
+  it('should return original value for non-strings', () => {
+    expect(applyTransforms(123, ['upper'])).toBe(123);
+    expect(applyTransforms(null, ['upper'])).toBe(null);
+  });
+});

--- a/packages/xlsx/README.md
+++ b/packages/xlsx/README.md
@@ -67,6 +67,7 @@ Use `{{path.to.value}}` for values that do not depend on the current row:
 - **Default values**: Use `||` to provide a fallback if a value is missing or null.
   - `{{user.name || N/A}}` -> renders "N/A" if `user.name` is missing or null.
   - `{{user.city || user.backupCity}}` -> tries to resolve `user.backupCity` if `user.city` is not found.
+- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`/`uppercase`, `lower`/`lowercase`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`. You can chain them: `{{title | trim | capitalize}}`.
 - If the key (or any intermediate segment) does not exist and no default is provided, the **marker is left as-is**.
 - If the resolved value is `null` or `undefined` and no default is provided, the cell becomes an empty string (`""`).
 


### PR DESCRIPTION
💡 **What:** Added new string transformations to the template interpolation engine.
🎯 **Why:** Users often need to format data for different contexts (e.g., URL slugs, database keys, class names) directly within their templates.
📦 **What it adds:**
- `pascalCase`: Converts strings to PascalCase.
- `snakeCase`: Converts strings to snake_case.
- `kebabCase`: Converts strings to kebab-case.
- `upperCase`/`lowerCase`: Aliases for better developer experience.
🚀 **How to use:** `{{ name | snakeCase }}` or `[[ items.name | kebabCase ]]`.
♻️ **Deps Free:** Uses only built-in JavaScript APIs and regex.
🎨 **Harmony:** Follows the existing transformation pattern and naming conventions in the `@interpolator` family.

---
*PR created automatically by Jules for task [5738456018355623338](https://jules.google.com/task/5738456018355623338) started by @galiprandi*