### PR TITLE
⚡ Spark: add titleCase transformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Used for static values that appear once in your document (e.g., a customer name,
 - **Nested Paths**: Supports dot notation like `{{user.profile.name}}`.
 - **Missing Data**: If a key is missing, the marker `{{key}}` stays in the cell for easier debugging.
 - **Null Values**: If a value is `null` or `undefined`, the cell is cleared.
-- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`, `lower`, `capitalize`, `trim`, `camelCase`. You can chain them: `{{title | trim | capitalize}}`.
+- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`, `lower`, `capitalize`, `trim`, `camelCase`, `titleCase`. You can chain them: `{{title | trim | capitalize}}`.
 
 #### Array-Based Row Expansion: `[[array.key]]`
 Used to repeat an entire row for every item in an array.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -87,6 +87,14 @@ export function applyTransforms(value: any, transforms: string[]): any {
           .toLowerCase()
           .replace(/^-+|-+$/g, '');
         break;
+      case 'titlecase':
+        result = result
+          .trim()
+          .replace(/([a-z])([A-Z])/g, '$1 $2')
+          .replace(/[^a-zA-Z0-9]+/g, ' ')
+          .toLowerCase()
+          .replace(/\b\w/g, (chr) => chr.toUpperCase());
+        break;
     }
   }
   return result;

--- a/packages/core/tests/index.test.ts
+++ b/packages/core/tests/index.test.ts
@@ -45,6 +45,13 @@ describe('applyTransforms', () => {
     expect(applyTransforms('hello_world', ['kebabcase'])).toBe('hello-world');
   });
 
+  it('should handle titlecase', () => {
+    expect(applyTransforms('hello world', ['titlecase'])).toBe('Hello World');
+    expect(applyTransforms('hello-world', ['titlecase'])).toBe('Hello World');
+    expect(applyTransforms('hello_world', ['titlecase'])).toBe('Hello World');
+    expect(applyTransforms('helloWorld', ['titlecase'])).toBe('Hello World');
+  });
+
   it('should handle chained transformations', () => {
     expect(applyTransforms('  hello world  ', ['trim', 'camelcase', 'capitalize'])).toBe('HelloWorld');
   });


### PR DESCRIPTION
💡 **What:** Added a new `titleCase` transformation to the `@interpolator/core` package.
🎯 **Why:** Users often need to format data keys or raw strings into human-readable titles (e.g., converting "user_profile" or "userProfile" to "User Profile").
📦 **What it adds:** A new `titlecase` option in the `applyTransforms` function, accessible via the `| titleCase` pipe in templates.
🚀 **How to use:** `{{ name | titleCase }}`. Example: "helloWorld" -> "Hello World", "first_name" -> "First Name".
♻️ **Deps Free:** Uses only built-in JavaScript/TypeScript functionality and existing regex patterns.
🎨 **Harmony:** Follows the existing transformation pattern in `@interpolator/core` and is immediately available to all packages using core resolution (like `@interpolator/xlsx`).

---
*PR created automatically by Jules for task [12004651339579795440](https://jules.google.com/task/12004651339579795440) started by @galiprandi*