### PR TITLE
⚡ Spark: Add JSON transformation and support non-string inputs

### DIFF
--- a/.axioma/spark.md
+++ b/.axioma/spark.md
@@ -43,3 +43,7 @@
 ## 2026-05-31 - [Piped Transformations for Template Markers]
 **Learning:** Adding a pipe operator (`|`) for string transformations (upper, lower, capitalize, trim, camelCase) provides users with powerful formatting capabilities directly in the template, reducing the need for data preprocessing. Chaining these transforms increases flexibility.
 **Pattern:** Decouple path resolution from value transformation. Resolve the value first, then apply a series of transformations. This allows the same transformation logic to be reused across different marker types (interpolation and array expansion) and data sources (main data and fallbacks).
+
+## 2026-06-20 - [Non-string Transformations and JSON Formatting]
+**Learning:** Limiting transformations to strings is an unnecessary constraint that limits the utility of the pipe operator. By allowing any value to enter the transformation chain and providing a `json` transform, users can debug their data or output complex objects as strings directly in the template.
+**Pattern:** Remove early type-exits in transformation utilities. Guard string-specific logic with type checks and add a universal `json` (stringification) transform to handle non-primitive data gracefully.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -37,63 +37,74 @@ export function resolvePath(obj: any, path: string): { found: boolean; value: an
 }
 
 export function applyTransforms(value: any, transforms: string[]): any {
-  if (value == null || typeof value !== 'string') return value;
-
   let result = value;
   for (const t of transforms) {
     const transform = t.trim().toLowerCase();
     switch (transform) {
       case 'upper':
       case 'uppercase':
-        result = result.toUpperCase();
+        if (typeof result === 'string') result = result.toUpperCase();
         break;
       case 'lower':
       case 'lowercase':
-        result = result.toLowerCase();
+        if (typeof result === 'string') result = result.toLowerCase();
         break;
       case 'capitalize':
-        result = result.charAt(0).toUpperCase() + result.slice(1);
+        if (typeof result === 'string') result = result.charAt(0).toUpperCase() + result.slice(1);
         break;
       case 'trim':
-        result = result.trim();
+        if (typeof result === 'string') result = result.trim();
         break;
       case 'camelcase':
-        result = result
-          .trim()
-          .replace(/[^a-zA-Z0-9]+(.)/g, (_, chr) => chr.toUpperCase())
-          .replace(/[^a-zA-Z0-9]+$/, '')
-          .replace(/^[A-Z]/, (chr) => chr.toLowerCase());
+        if (typeof result === 'string') {
+          result = result
+            .trim()
+            .replace(/[^a-zA-Z0-9]+(.)/g, (_, chr) => chr.toUpperCase())
+            .replace(/[^a-zA-Z0-9]+$/, '')
+            .replace(/^[A-Z]/, (chr) => chr.toLowerCase());
+        }
         break;
       case 'pascalcase':
-        result = result
-          .trim()
-          .replace(/[^a-zA-Z0-9]+(.)/g, (_, chr) => chr.toUpperCase())
-          .replace(/[^a-zA-Z0-9]+$/, '')
-          .replace(/^[a-z]/, (chr) => chr.toUpperCase());
+        if (typeof result === 'string') {
+          result = result
+            .trim()
+            .replace(/[^a-zA-Z0-9]+(.)/g, (_, chr) => chr.toUpperCase())
+            .replace(/[^a-zA-Z0-9]+$/, '')
+            .replace(/^[a-z]/, (chr) => chr.toUpperCase());
+        }
         break;
       case 'snakecase':
-        result = result
-          .trim()
-          .replace(/([a-z])([A-Z])/g, '$1_$2')
-          .replace(/[^a-zA-Z0-9]+/g, '_')
-          .toLowerCase()
-          .replace(/^_+|_+$/g, '');
+        if (typeof result === 'string') {
+          result = result
+            .trim()
+            .replace(/([a-z])([A-Z])/g, '$1_$2')
+            .replace(/[^a-zA-Z0-9]+/g, '_')
+            .toLowerCase()
+            .replace(/^_+|_+$/g, '');
+        }
         break;
       case 'kebabcase':
-        result = result
-          .trim()
-          .replace(/([a-z])([A-Z])/g, '$1-$2')
-          .replace(/[^a-zA-Z0-9]+/g, '-')
-          .toLowerCase()
-          .replace(/^-+|-+$/g, '');
+        if (typeof result === 'string') {
+          result = result
+            .trim()
+            .replace(/([a-z])([A-Z])/g, '$1-$2')
+            .replace(/[^a-zA-Z0-9]+/g, '-')
+            .toLowerCase()
+            .replace(/^-+|-+$/g, '');
+        }
         break;
       case 'titlecase':
-        result = result
-          .trim()
-          .replace(/([a-z])([A-Z])/g, '$1 $2')
-          .replace(/[^a-zA-Z0-9]+/g, ' ')
-          .replace(/\b([a-z])/g, (_, chr) => chr.toUpperCase())
-          .trim();
+        if (typeof result === 'string') {
+          result = result
+            .trim()
+            .replace(/([a-z])([A-Z])/g, '$1 $2')
+            .replace(/[^a-zA-Z0-9]+/g, ' ')
+            .replace(/\b([a-z])/g, (_, chr) => chr.toUpperCase())
+            .trim();
+        }
+        break;
+      case 'json':
+        result = JSON.stringify(result, null, 2);
         break;
     }
   }

--- a/packages/core/tests/index.test.ts
+++ b/packages/core/tests/index.test.ts
@@ -57,8 +57,22 @@ describe('applyTransforms', () => {
     expect(applyTransforms('  hello world  ', ['trim', 'camelcase', 'capitalize'])).toBe('HelloWorld');
   });
 
-  it('should return original value for non-strings', () => {
+  it('should return original value for non-strings when using string-only transforms', () => {
     expect(applyTransforms(123, ['upper'])).toBe(123);
     expect(applyTransforms(null, ['upper'])).toBe(null);
+  });
+
+  it('should handle json transformation', () => {
+    const obj = { a: 1, b: 'hello' };
+    expect(applyTransforms(obj, ['json'])).toBe(JSON.stringify(obj, null, 2));
+    expect(applyTransforms([1, 2, 3], ['json'])).toBe(JSON.stringify([1, 2, 3], null, 2));
+    expect(applyTransforms('hello', ['json'])).toBe('"hello"');
+  });
+
+  it('should handle chained transformations with json', () => {
+    const obj = { name: 'spark' };
+    // json -> uppercase (no effect as json returns string, but uppercase works on it)
+    const jsonStr = JSON.stringify(obj, null, 2);
+    expect(applyTransforms(obj, ['json', 'uppercase'])).toBe(jsonStr.toUpperCase());
   });
 });


### PR DESCRIPTION
💡 **What:** Added a new `json` transformation to the `@interpolator/core` package and updated `applyTransforms` to handle non-string inputs.

🎯 **Why:** Users often need to debug their templates by inspecting the data objects or need to output complex data as formatted JSON strings. Previously, `applyTransforms` would immediately return the original value if it wasn't a string, preventing any non-string-to-string conversions.

📦 **What it adds:**
- `json` transform: `{{ someObject | json }}` now returns a pretty-printed JSON string.
- Support for non-string inputs in the transformation pipeline.

🚀 **How to use:**
In your template:
`{{ user | json }}` -> `{\n  "name": "Spark",\n  "role": "Agent"\n}`
`{{ items | json | uppercase }}` -> `[ ... ]` (all uppercase)

♻️ **Deps Free:** Uses only built-in `JSON.stringify`.

🎨 **Harmony:** Fits perfectly into the existing piped transformation pattern and improves the robustness of the core utility.

---
*PR created automatically by Jules for task [2310471470786741675](https://jules.google.com/task/2310471470786741675) started by @galiprandi*