### PR TITLE
⚡ Spark: Utility Transforms (join, first, last, length, plural, round)

### DIFF
--- a/.axioma/spark.md
+++ b/.axioma/spark.md
@@ -47,3 +47,7 @@
 ## 2026-06-20 - [Non-string Transformations and JSON Formatting]
 **Learning:** Limiting transformations to strings is an unnecessary constraint that limits the utility of the pipe operator. By allowing any value to enter the transformation chain and providing a `json` transform, users can debug their data or output complex objects as strings directly in the template.
 **Pattern:** Remove early type-exits in transformation utilities. Guard string-specific logic with type checks and add a universal `json` (stringification) transform to handle non-primitive data gracefully.
+
+## 2026-06-25 - [Utility-Driven Data Presentation]
+**Learning:** Users often need minor data formatting (joining lists, pluralization, rounding numbers) that doesn't justify a new dependency or complex backend preprocessing. Adding lightweight, type-guarded transforms directly to the core resolution engine provides high value with negligible overhead.
+**Pattern:** Implement "micro-transforms" like `join`, `plural`, and `round` with defensive type checking. This ensures the template engine remains robust while offering flexible presentation logic for various data types (arrays, numbers, strings).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ After interpolation with the data above, the result would be:
 - **Type Preservation**: If the cell contains *only* the `{{key}}` marker, the resulting cell will have the same type as the data (e.g., Number, Date, Boolean).
 - Supports nested paths: `{{user.profile.email}}`.
 - **Default values**: `{{path || fallback}}`. Fallback can be a literal string or another path.
-- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`/`uppercase`, `lower`/`lowercase`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`. You can chain them: `{{title | trim | capitalize}}`.
+- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`/`uppercase`, `lower`/`lowercase`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `join`, `first`, `last`, `length`, `plural`, `round`. You can chain them: `{{title | trim | capitalize}}`.
 - If the key is missing and no default is provided, the marker remains in the cell as-is.
 - If the value is `null` or `undefined` and no default is provided, the cell becomes empty (`""`).
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Used for static values that appear once in your document (e.g., a customer name,
 - **Nested Paths**: Supports dot notation like `{{user.profile.name}}`.
 - **Missing Data**: If a key is missing, the marker `{{key}}` stays in the cell for easier debugging.
 - **Null Values**: If a value is `null` or `undefined`, the cell is cleared.
-- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`, `lower`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`. You can chain them: `{{title | trim | capitalize}}`.
+- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`, `lower`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `join`, `first`, `last`, `length`, `plural`, `round`. You can chain them: `{{title | trim | capitalize}}`.
 
 #### Array-Based Row Expansion: `[[array.key]]`
 Used to repeat an entire row for every item in an array.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -106,6 +106,28 @@ export function applyTransforms(value: any, transforms: string[]): any {
       case 'json':
         result = JSON.stringify(result, null, 2);
         break;
+      case 'join':
+        if (Array.isArray(result)) result = result.join(', ');
+        break;
+      case 'first':
+        if (Array.isArray(result) || typeof result === 'string') {
+          result = result.length > 0 ? result[0] : undefined;
+        }
+        break;
+      case 'last':
+        if (Array.isArray(result) || typeof result === 'string') {
+          result = result.length > 0 ? result[result.length - 1] : undefined;
+        }
+        break;
+      case 'length':
+        if (Array.isArray(result) || typeof result === 'string') result = result.length;
+        break;
+      case 'plural':
+        if (typeof result === 'number') result = result === 1 ? '' : 's';
+        break;
+      case 'round':
+        if (typeof result === 'number') result = Math.round(result);
+        break;
     }
   }
   return result;

--- a/packages/core/tests/index.test.ts
+++ b/packages/core/tests/index.test.ts
@@ -75,4 +75,47 @@ describe('applyTransforms', () => {
     const jsonStr = JSON.stringify(obj, null, 2);
     expect(applyTransforms(obj, ['json', 'uppercase'])).toBe(jsonStr.toUpperCase());
   });
+
+  it('should handle join transformation', () => {
+    expect(applyTransforms(['a', 'b', 'c'], ['join'])).toBe('a, b, c');
+    expect(applyTransforms([], ['join'])).toBe('');
+    expect(applyTransforms('not an array', ['join'])).toBe('not an array');
+  });
+
+  it('should handle first transformation', () => {
+    expect(applyTransforms(['a', 'b', 'c'], ['first'])).toBe('a');
+    expect(applyTransforms('hello', ['first'])).toBe('h');
+    expect(applyTransforms([], ['first'])).toBeUndefined();
+    expect(applyTransforms('', ['first'])).toBeUndefined();
+  });
+
+  it('should handle last transformation', () => {
+    expect(applyTransforms(['a', 'b', 'c'], ['last'])).toBe('c');
+    expect(applyTransforms('hello', ['last'])).toBe('o');
+    expect(applyTransforms([], ['last'])).toBeUndefined();
+    expect(applyTransforms('', ['last'])).toBeUndefined();
+  });
+
+  it('should handle length transformation', () => {
+    expect(applyTransforms(['a', 'b', 'c'], ['length'])).toBe(3);
+    expect(applyTransforms('hello', ['length'])).toBe(5);
+    expect(applyTransforms([], ['length'])).toBe(0);
+    expect(applyTransforms('', ['length'])).toBe(0);
+  });
+
+  it('should handle plural transformation', () => {
+    expect(applyTransforms(0, ['plural'])).toBe('s');
+    expect(applyTransforms(1, ['plural'])).toBe('');
+    expect(applyTransforms(2, ['plural'])).toBe('s');
+    expect(applyTransforms(1.5, ['plural'])).toBe('s');
+    expect(applyTransforms('not a number', ['plural'])).toBe('not a number');
+  });
+
+  it('should handle round transformation', () => {
+    expect(applyTransforms(1.4, ['round'])).toBe(1);
+    expect(applyTransforms(1.5, ['round'])).toBe(2);
+    expect(applyTransforms(1.6, ['round'])).toBe(2);
+    expect(applyTransforms(-1.5, ['round'])).toBe(-1); // Math.round(-1.5) is -1
+    expect(applyTransforms('not a number', ['round'])).toBe('not a number');
+  });
 });


### PR DESCRIPTION
💡 **What:** Added 6 new utility transforms to the core interpolation engine: `join`, `first`, `last`, `length`, `plural`, and `round`.
🎯 **Why:** To provide users with common formatting capabilities directly in templates, reducing the need for data preprocessing.
📦 **What it adds:**
- `join`: Joins arrays with ", ".
- `first` / `last`: Extracts elements from arrays or strings.
- `length`: Gets size of arrays or strings.
- `plural`: Returns "s" if value is not 1.
- `round`: Rounds numbers.
🚀 **How to use:** `{{items | length}}`, `{{tags | join}}`, `{{count}} error{{count | plural}}`, `{{price | round}}`.
♻️ **Deps Free:** Zero new dependencies added.
🎨 **Harmony:** Fits perfectly into the existing piped transform architecture with defensive type-checking.

---
*PR created automatically by Jules for task [16947723705719916855](https://jules.google.com/task/16947723705719916855) started by @galiprandi*