### PR TITLE
⚡ Spark: Numeric Math Transforms

### DIFF
--- a/.axioma/spark.md
+++ b/.axioma/spark.md
@@ -51,3 +51,7 @@
 ## 2026-06-25 - [Utility-Driven Data Presentation]
 **Learning:** Users often need minor data formatting (joining lists, pluralization, rounding numbers) that doesn't justify a new dependency or complex backend preprocessing. Adding lightweight, type-guarded transforms directly to the core resolution engine provides high value with negligible overhead.
 **Pattern:** Implement "micro-transforms" like `join`, `plural`, and `round` with defensive type checking. This ensures the template engine remains robust while offering flexible presentation logic for various data types (arrays, numbers, strings).
+
+## 2026-06-30 - [Numeric Math Transforms]
+**Learning:** Providing basic math operations (floor, ceil, abs) alongside rounding allows users to handle financial or statistical data presentation directly in templates without upstream modification.
+**Pattern:** Use type-guarded `Math` function wrappers to extend the transformation engine safely for numeric data types.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -128,6 +128,15 @@ export function applyTransforms(value: any, transforms: string[]): any {
       case 'round':
         if (typeof result === 'number') result = Math.round(result);
         break;
+      case 'floor':
+        if (typeof result === 'number') result = Math.floor(result);
+        break;
+      case 'ceil':
+        if (typeof result === 'number') result = Math.ceil(result);
+        break;
+      case 'abs':
+        if (typeof result === 'number') result = Math.abs(result);
+        break;
     }
   }
   return result;

--- a/packages/core/tests/index.test.ts
+++ b/packages/core/tests/index.test.ts
@@ -118,4 +118,22 @@ describe('applyTransforms', () => {
     expect(applyTransforms(-1.5, ['round'])).toBe(-1); // Math.round(-1.5) is -1
     expect(applyTransforms('not a number', ['round'])).toBe('not a number');
   });
+
+  it('should handle floor transformation', () => {
+    expect(applyTransforms(1.9, ['floor'])).toBe(1);
+    expect(applyTransforms(-1.1, ['floor'])).toBe(-2);
+    expect(applyTransforms('not a number', ['floor'])).toBe('not a number');
+  });
+
+  it('should handle ceil transformation', () => {
+    expect(applyTransforms(1.1, ['ceil'])).toBe(2);
+    expect(applyTransforms(-1.9, ['ceil'])).toBe(-1);
+    expect(applyTransforms('not a number', ['ceil'])).toBe('not a number');
+  });
+
+  it('should handle abs transformation', () => {
+    expect(applyTransforms(-5, ['abs'])).toBe(5);
+    expect(applyTransforms(5, ['abs'])).toBe(5);
+    expect(applyTransforms('not a number', ['abs'])).toBe('not a number');
+  });
 });


### PR DESCRIPTION
💡 **What:** Added new numeric transformations to the core template engine.
🎯 **Why:** Users often need basic mathematical adjustments (rounding down/up or absolute values) for data presentation without modifying the source data.
📦 **What it adds:** Three new transforms: `floor`, `ceil`, and `abs`.
🚀 **How to use:** `{{ value | floor }}`, `{{ value | ceil }}`, or `{{ value | abs }}`.
♻️ **Deps Free:** Uses only built-in `Math` functions.
🎨 **Harmony:** Follows the existing pattern of type-guarded transformations in `@interpolator/core`.

---
*PR created automatically by Jules for task [4314768869583194803](https://jules.google.com/task/4314768869583194803) started by @galiprandi*