### PR TITLE
⚡ Spark: Add unique transform

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ After interpolation with the data above, the result would be:
 - **Type Preservation**: If the cell contains *only* the `{{key}}` marker, the resulting cell will have the same type as the data (e.g., Number, Date, Boolean).
 - Supports nested paths: `{{user.profile.email}}`.
 - **Default values**: `{{path || fallback}}`. Fallback can be a literal string or another path.
-- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`/`uppercase`, `lower`/`lowercase`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `join`, `first`, `last`, `length`, `plural`, `round`. You can chain them: `{{title | trim | capitalize}}`.
+- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`/`uppercase`, `lower`/`lowercase`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `join`, `unique`, `first`, `last`, `length`, `plural`, `round`. You can chain them: `{{title | trim | capitalize}}`.
 - If the key is missing and no default is provided, the marker remains in the cell as-is.
 - If the value is `null` or `undefined` and no default is provided, the cell becomes empty (`""`).
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Used for static values that appear once in your document (e.g., a customer name,
 - **Nested Paths**: Supports dot notation like `{{user.profile.name}}`.
 - **Missing Data**: If a key is missing, the marker `{{key}}` stays in the cell for easier debugging.
 - **Null Values**: If a value is `null` or `undefined`, the cell is cleared.
-- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`, `lower`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `join`, `first`, `last`, `length`, `plural`, `round`. You can chain them: `{{title | trim | capitalize}}`.
+- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`, `lower`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `join`, `unique`, `first`, `last`, `length`, `plural`, `round`. You can chain them: `{{title | trim | capitalize}}`.
 
 #### Array-Based Row Expansion: `[[array.key]]`
 Used to repeat an entire row for every item in an array.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -109,6 +109,9 @@ export function applyTransforms(value: any, transforms: string[]): any {
       case 'join':
         if (Array.isArray(result)) result = result.join(', ');
         break;
+      case 'unique':
+        if (Array.isArray(result)) result = Array.from(new Set(result));
+        break;
       case 'first':
         if (Array.isArray(result) || typeof result === 'string') {
           result = result.length > 0 ? result[0] : undefined;

--- a/packages/core/tests/index.test.ts
+++ b/packages/core/tests/index.test.ts
@@ -82,6 +82,13 @@ describe('applyTransforms', () => {
     expect(applyTransforms('not an array', ['join'])).toBe('not an array');
   });
 
+  it('should handle unique transformation', () => {
+    expect(applyTransforms(['a', 'b', 'a', 'c', 'b'], ['unique'])).toEqual(['a', 'b', 'c']);
+    expect(applyTransforms([1, 2, 1, 3, 2], ['unique'])).toEqual([1, 2, 3]);
+    expect(applyTransforms([], ['unique'])).toEqual([]);
+    expect(applyTransforms('not an array', ['unique'])).toBe('not an array');
+  });
+
   it('should handle first transformation', () => {
     expect(applyTransforms(['a', 'b', 'c'], ['first'])).toBe('a');
     expect(applyTransforms('hello', ['first'])).toBe('h');


### PR DESCRIPTION
💡 **What:** Added a new `unique` transformation to the core interpolation engine.
🎯 **Why:** To allow users to easily deduplicate arrays (e.g., categories, tags, or IDs) directly within their templates without needing to preprocess the data.
📦 **What it adds:** A `unique` transform that can be used with the pipe operator in both `{{ }}` and `[[ ]]` markers.
🚀 **How to use:** `{{ categories | unique | join }}` or `[[ items.tags | unique ]]`.
♻️ **Deps Free:** Uses built-in `Set` and `Array.from`.
🎨 **Harmony:** Follows the existing transform pattern in `@interpolator/core` and aligns with other array utilities like `join`, `first`, and `last`.

---
*PR created automatically by Jules for task [13746945474587405249](https://jules.google.com/task/13746945474587405249) started by @galiprandi*