### PR TITLE
⚡ Spark: [New Transforms] min, max, empty, notempty, boolean

### DIFF
--- a/.axioma/spark.md
+++ b/.axioma/spark.md
@@ -59,3 +59,7 @@
 ## 2026-06-30 - [Numeric Math Transforms]
 **Learning:** Providing basic math operations (floor, ceil, abs) alongside rounding allows users to handle financial or statistical data presentation directly in templates without upstream modification.
 **Pattern:** Use type-guarded `Math` function wrappers to extend the transformation engine safely for numeric data types.
+
+## 2026-07-10 - [Conditional Logic and Array Extremes]
+**Learning:** Adding `empty` and `notempty` transforms simplifies declarative conditional rendering (like hiding "No results" sections) without requiring backend data preprocessing. Providing `min` and `max` for arrays allows for quick data insights directly in the template.
+**Pattern:** Implement comprehensive emptiness checks (null, undefined, '', []) as a single transform. For array extremes, ensure robust numeric filtering to handle mixed-type arrays gracefully.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ After interpolation with the data above, the result would be:
 - **Type Preservation**: If the cell contains *only* the `{{key}}` marker, the resulting cell will have the same type as the data (e.g., Number, Date, Boolean).
 - Supports nested paths: `{{user.profile.email}}`.
 - **Default values**: `{{path || fallback}}`. Fallback can be a literal string or another path.
-- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`/`uppercase`, `lower`/`lowercase`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `join`, `unique`, `first`, `last`, `length`, `plural`, `round`, `reverse`, `sort`, `compact`, `sum`, `avg`. You can chain them: `{{title | trim | capitalize}}`.
+- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`/`uppercase`, `lower`/`lowercase`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `join`, `unique`, `first`, `last`, `length`, `plural`, `round`, `reverse`, `sort`, `compact`, `sum`, `avg`, `min`, `max`, `empty`, `notEmpty`, `boolean`. You can chain them: `{{title | trim | capitalize}}`.
 - If the key is missing and no default is provided, the marker remains in the cell as-is.
 - If the value is `null` or `undefined` and no default is provided, the cell becomes empty (`""`).
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Used for static values that appear once in your document (e.g., a customer name,
 - **Nested Paths**: Supports dot notation like `{{user.profile.name}}`.
 - **Missing Data**: If a key is missing, the marker `{{key}}` stays in the cell for easier debugging.
 - **Null Values**: If a value is `null` or `undefined`, the cell is cleared.
-- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`, `lower`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `join`, `unique`, `first`, `last`, `length`, `plural`, `round`, `reverse`, `sort`, `compact`, `sum`, `avg`. You can chain them: `{{title | trim | capitalize}}`.
+- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`, `lower`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `join`, `unique`, `first`, `last`, `length`, `plural`, `round`, `reverse`, `sort`, `compact`, `sum`, `avg`, `min`, `max`, `empty`, `notEmpty`, `boolean`. You can chain them: `{{title | trim | capitalize}}`.
 
 #### Array-Based Row Expansion: `[[array.key]]`
 Used to repeat an entire row for every item in an array.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -171,6 +171,36 @@ export function applyTransforms(value: any, transforms: string[]): any {
           result = nums.length > 0 ? nums.reduce((a, b) => a + b, 0) / nums.length : 0;
         }
         break;
+      case 'min':
+        if (Array.isArray(result)) {
+          const nums = result.map(Number).filter((n) => !Number.isNaN(n));
+          result = nums.length > 0 ? Math.min(...nums) : undefined;
+        }
+        break;
+      case 'max':
+        if (Array.isArray(result)) {
+          const nums = result.map(Number).filter((n) => !Number.isNaN(n));
+          result = nums.length > 0 ? Math.max(...nums) : undefined;
+        }
+        break;
+      case 'empty':
+        result =
+          result === null ||
+          result === undefined ||
+          result === '' ||
+          (Array.isArray(result) && result.length === 0);
+        break;
+      case 'notempty':
+        result = !(
+          result === null ||
+          result === undefined ||
+          result === '' ||
+          (Array.isArray(result) && result.length === 0)
+        );
+        break;
+      case 'boolean':
+        result = Boolean(result);
+        break;
     }
   }
   return result;

--- a/packages/core/tests/index.test.ts
+++ b/packages/core/tests/index.test.ts
@@ -180,4 +180,49 @@ describe('applyTransforms', () => {
     expect(applyTransforms([], ['avg'])).toBe(0);
     expect(applyTransforms('not an array', ['avg'])).toBe('not an array');
   });
+
+  it('should handle min transformation', () => {
+    expect(applyTransforms([1, 2, 3], ['min'])).toBe(1);
+    expect(applyTransforms(['1', '2', '3'], ['min'])).toBe(1);
+    expect(applyTransforms([10, -5, 2], ['min'])).toBe(-5);
+    expect(applyTransforms([], ['min'])).toBeUndefined();
+    expect(applyTransforms('not an array', ['min'])).toBe('not an array');
+  });
+
+  it('should handle max transformation', () => {
+    expect(applyTransforms([1, 2, 3], ['max'])).toBe(3);
+    expect(applyTransforms(['1', '2', '3'], ['max'])).toBe(3);
+    expect(applyTransforms([10, -5, 2], ['max'])).toBe(10);
+    expect(applyTransforms([], ['max'])).toBeUndefined();
+    expect(applyTransforms('not an array', ['max'])).toBe('not an array');
+  });
+
+  it('should handle empty transformation', () => {
+    expect(applyTransforms('', ['empty'])).toBe(true);
+    expect(applyTransforms([], ['empty'])).toBe(true);
+    expect(applyTransforms(null, ['empty'])).toBe(true);
+    expect(applyTransforms(undefined, ['empty'])).toBe(true);
+    expect(applyTransforms('hello', ['empty'])).toBe(false);
+    expect(applyTransforms([1], ['empty'])).toBe(false);
+    expect(applyTransforms(0, ['empty'])).toBe(false);
+  });
+
+  it('should handle notempty transformation', () => {
+    expect(applyTransforms('', ['notempty'])).toBe(false);
+    expect(applyTransforms([], ['notempty'])).toBe(false);
+    expect(applyTransforms(null, ['notempty'])).toBe(false);
+    expect(applyTransforms(undefined, ['notempty'])).toBe(false);
+    expect(applyTransforms('hello', ['notempty'])).toBe(true);
+    expect(applyTransforms([1], ['notempty'])).toBe(true);
+    expect(applyTransforms(0, ['notempty'])).toBe(true);
+  });
+
+  it('should handle boolean transformation', () => {
+    expect(applyTransforms(1, ['boolean'])).toBe(true);
+    expect(applyTransforms(0, ['boolean'])).toBe(false);
+    expect(applyTransforms('hello', ['boolean'])).toBe(true);
+    expect(applyTransforms('', ['boolean'])).toBe(false);
+    expect(applyTransforms([], ['boolean'])).toBe(true);
+    expect(applyTransforms(null, ['boolean'])).toBe(false);
+  });
 });


### PR DESCRIPTION
💡 **What:** Added 5 new utility transforms to the core interpolation engine: `min`, `max`, `empty`, `notempty`, and `boolean`.

🎯 **Why:** These transforms improve template flexibility, especially for conditional logic (e.g., hiding sections when an array is empty) and basic data presentation without needing to preprocess data.

📦 **What it adds:**
- `min` / `max`: Returns the minimum or maximum numeric value from an array.
- `empty` / `notempty`: Returns a boolean indicating if a value is nullish, an empty string, or an empty array.
- `boolean`: Explicitly casts any value to a boolean.

🚀 **How to use:**
- `[[items | empty]]` - Ideal for conditional rows in XLSX to show a "No Data" message.
- `{{prices | min}}` - Display the lowest price in a collection.
- `{{status | boolean}}` - Ensure a value is treated as a boolean for logic checks.

♻️ **Deps Free:** No new dependencies added.

🎨 **Harmony:** Follows the existing pattern for piped transforms in `@interpolator/core` and is immediately available in all format-specific packages like `@interpolator/xlsx`.

---
*PR created automatically by Jules for task [11839869302441205772](https://jules.google.com/task/11839869302441205772) started by @galiprandi*