### PR TITLE
⚡ Spark: Add min and max transforms

### DIFF
--- a/.axioma/spark.md
+++ b/.axioma/spark.md
@@ -59,3 +59,7 @@
 ## 2026-06-30 - [Numeric Math Transforms]
 **Learning:** Providing basic math operations (floor, ceil, abs) alongside rounding allows users to handle financial or statistical data presentation directly in templates without upstream modification.
 **Pattern:** Use type-guarded `Math` function wrappers to extend the transformation engine safely for numeric data types.
+
+## 2026-07-10 - [Numeric Extremes and Nullability]
+**Learning:** When implementing numeric aggregations like `min` and `max`, returning `undefined` for empty or non-numeric collections is more accurate than defaulting to `0`. This allows template authors to use default values (e.g., `{{ items | min || N/A }}`) to handle missing data explicitly.
+**Pattern:** Prefer `undefined` over fallback values for collection reductions when the identity element (like 0 for sum) could be misinterpreted as a valid result from the data.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ After interpolation with the data above, the result would be:
 - **Type Preservation**: If the cell contains *only* the `{{key}}` marker, the resulting cell will have the same type as the data (e.g., Number, Date, Boolean).
 - Supports nested paths: `{{user.profile.email}}`.
 - **Default values**: `{{path || fallback}}`. Fallback can be a literal string or another path.
-- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`/`uppercase`, `lower`/`lowercase`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `join`, `unique`, `first`, `last`, `length`, `plural`, `round`, `reverse`, `sort`, `compact`, `sum`, `avg`. You can chain them: `{{title | trim | capitalize}}`.
+- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`/`uppercase`, `lower`/`lowercase`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `join`, `unique`, `first`, `last`, `length`, `plural`, `round`, `reverse`, `sort`, `compact`, `sum`, `avg`, `min`, `max`. You can chain them: `{{title | trim | capitalize}}`.
 - If the key is missing and no default is provided, the marker remains in the cell as-is.
 - If the value is `null` or `undefined` and no default is provided, the cell becomes empty (`""`).
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -171,6 +171,18 @@ export function applyTransforms(value: any, transforms: string[]): any {
           result = nums.length > 0 ? nums.reduce((a, b) => a + b, 0) / nums.length : 0;
         }
         break;
+      case 'min':
+        if (Array.isArray(result)) {
+          const nums = result.map(Number).filter((n) => !Number.isNaN(n));
+          result = nums.length > 0 ? Math.min(...nums) : undefined;
+        }
+        break;
+      case 'max':
+        if (Array.isArray(result)) {
+          const nums = result.map(Number).filter((n) => !Number.isNaN(n));
+          result = nums.length > 0 ? Math.max(...nums) : undefined;
+        }
+        break;
     }
   }
   return result;

--- a/packages/core/tests/index.test.ts
+++ b/packages/core/tests/index.test.ts
@@ -180,4 +180,22 @@ describe('applyTransforms', () => {
     expect(applyTransforms([], ['avg'])).toBe(0);
     expect(applyTransforms('not an array', ['avg'])).toBe('not an array');
   });
+
+  it('should handle min transformation', () => {
+    expect(applyTransforms([2, 4, 1, 6], ['min'])).toBe(1);
+    expect(applyTransforms(['2', '4', '1', '6'], ['min'])).toBe(1);
+    expect(applyTransforms([2, 'invalid', 1], ['min'])).toBe(1);
+    expect(applyTransforms([], ['min'])).toBeUndefined();
+    expect(applyTransforms(['invalid'], ['min'])).toBeUndefined();
+    expect(applyTransforms('not an array', ['min'])).toBe('not an array');
+  });
+
+  it('should handle max transformation', () => {
+    expect(applyTransforms([2, 4, 1, 6], ['max'])).toBe(6);
+    expect(applyTransforms(['2', '4', '1', '6'], ['max'])).toBe(6);
+    expect(applyTransforms([2, 'invalid', 6], ['max'])).toBe(6);
+    expect(applyTransforms([], ['max'])).toBeUndefined();
+    expect(applyTransforms(['invalid'], ['max'])).toBeUndefined();
+    expect(applyTransforms('not an array', ['max'])).toBe('not an array');
+  });
 });


### PR DESCRIPTION
💡 **What:** Added `min` and `max` transformation filters to the core interpolation engine.
🎯 **Why:** Users need basic statistical operations (finding the smallest or largest value in a list) directly in their templates without needing to pre-process the data.
📦 **What it adds:** Two new transforms for arrays: `| min` and `| max`.
🚀 **How to use:** `{{ prices | min }}` or `[[items.qty | max]]`.
♻️ **Deps Free:** Uses only built-in `Math.min`/`Math.max` and array methods.
🎨 **Harmony:** Follows the established pattern of `sum` and `avg` transforms, including safe numeric handling and type guarding.

---
*PR created automatically by Jules for task [5670018837877460299](https://jules.google.com/task/5670018837877460299) started by @galiprandi*