### PR TITLE
⚡ Spark: add min, max, empty, notempty, and boolean transforms

### DIFF
--- a/.axioma/spark.md
+++ b/.axioma/spark.md
@@ -59,3 +59,7 @@
 ## 2026-06-30 - [Numeric Math Transforms]
 **Learning:** Providing basic math operations (floor, ceil, abs) alongside rounding allows users to handle financial or statistical data presentation directly in templates without upstream modification.
 **Pattern:** Use type-guarded `Math` function wrappers to extend the transformation engine safely for numeric data types.
+
+## 2026-07-10 - [State Validation and Numeric Aggregation Transforms]
+**Learning:** Adding explicit state validation transforms (`empty`, `notempty`, `boolean`) empowers template authors to handle conditional logic and type casting without upstream data changes. Completing the numeric aggregation set with `min` and `max` provides parity with standard spreadsheet functions.
+**Pattern:** Use broad truthiness checks for `empty` (null, undefined, '', empty array) to provide a robust "is this usable?" check for template authors.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ After interpolation with the data above, the result would be:
 - **Type Preservation**: If the cell contains *only* the `{{key}}` marker, the resulting cell will have the same type as the data (e.g., Number, Date, Boolean).
 - Supports nested paths: `{{user.profile.email}}`.
 - **Default values**: `{{path || fallback}}`. Fallback can be a literal string or another path.
-- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`/`uppercase`, `lower`/`lowercase`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `join`, `unique`, `first`, `last`, `length`, `plural`, `round`, `reverse`, `sort`, `compact`, `sum`, `avg`. You can chain them: `{{title | trim | capitalize}}`.
+- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`/`uppercase`, `lower`/`lowercase`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `join`, `unique`, `first`, `last`, `length`, `plural`, `round`, `reverse`, `sort`, `compact`, `sum`, `avg`, `min`, `max`, `empty`, `notempty`, `boolean`. You can chain them: `{{title | trim | capitalize}}`.
 - If the key is missing and no default is provided, the marker remains in the cell as-is.
 - If the value is `null` or `undefined` and no default is provided, the cell becomes empty (`""`).
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,176 +2,220 @@
 // - Marker parser
 // - Nested path resolver
 // - Common types
-export function parseMarkers(template: string): Array<{ type: 'interpolation' | 'array'; path: string; full: string }> {
-  const regex = /(\{\{|\[\[)\s*([^\]}]+)\s*(\}\}|\]\])/g;
-  const matches: Array<{ type: 'interpolation' | 'array'; path: string; full: string }> = [];
-  let match;
+export function parseMarkers(
+	template: string,
+): Array<{ type: "interpolation" | "array"; path: string; full: string }> {
+	const regex = /(\{\{|\[\[)\s*([^\]}]+)\s*(\}\}|\]\])/g;
+	const matches: Array<{
+		type: "interpolation" | "array";
+		path: string;
+		full: string;
+	}> = [];
+	let match;
 
-  while ((match = regex.exec(template)) !== null) {
-    const [full, open, path, close] = match;
-    matches.push({
-      type: open === '{{' ? 'interpolation' : 'array',
-      path,
-      full
-    });
-  }
+	while ((match = regex.exec(template)) !== null) {
+		const [full, open, path, close] = match;
+		matches.push({
+			type: open === "{{" ? "interpolation" : "array",
+			path,
+			full,
+		});
+	}
 
-  return matches;
+	return matches;
 }
 
-export function resolvePath(obj: any, path: string): { found: boolean; value: any } {
-  const keys = path.split('.');
-  let current = obj;
+export function resolvePath(
+	obj: any,
+	path: string,
+): { found: boolean; value: any } {
+	const keys = path.split(".");
+	let current = obj;
 
-  for (const key of keys) {
-    if (current == null || typeof current !== 'object') {
-      return { found: false, value: undefined };
-    }
-    if (!(key in current)) {
-      return { found: false, value: undefined };
-    }
-    current = current[key];
-  }
+	for (const key of keys) {
+		if (current == null || typeof current !== "object") {
+			return { found: false, value: undefined };
+		}
+		if (!(key in current)) {
+			return { found: false, value: undefined };
+		}
+		current = current[key];
+	}
 
-  return { found: true, value: current };
+	return { found: true, value: current };
 }
 
 export function applyTransforms(value: any, transforms: string[]): any {
-  let result = value;
-  for (const t of transforms) {
-    const transform = t.trim().toLowerCase();
-    switch (transform) {
-      case 'upper':
-      case 'uppercase':
-        if (typeof result === 'string') result = result.toUpperCase();
-        break;
-      case 'lower':
-      case 'lowercase':
-        if (typeof result === 'string') result = result.toLowerCase();
-        break;
-      case 'capitalize':
-        if (typeof result === 'string') result = result.charAt(0).toUpperCase() + result.slice(1);
-        break;
-      case 'trim':
-        if (typeof result === 'string') result = result.trim();
-        break;
-      case 'camelcase':
-        if (typeof result === 'string') {
-          result = result
-            .trim()
-            .replace(/[^a-zA-Z0-9]+(.)/g, (_, chr) => chr.toUpperCase())
-            .replace(/[^a-zA-Z0-9]+$/, '')
-            .replace(/^[A-Z]/, (chr) => chr.toLowerCase());
-        }
-        break;
-      case 'pascalcase':
-        if (typeof result === 'string') {
-          result = result
-            .trim()
-            .replace(/[^a-zA-Z0-9]+(.)/g, (_, chr) => chr.toUpperCase())
-            .replace(/[^a-zA-Z0-9]+$/, '')
-            .replace(/^[a-z]/, (chr) => chr.toUpperCase());
-        }
-        break;
-      case 'snakecase':
-        if (typeof result === 'string') {
-          result = result
-            .trim()
-            .replace(/([a-z])([A-Z])/g, '$1_$2')
-            .replace(/[^a-zA-Z0-9]+/g, '_')
-            .toLowerCase()
-            .replace(/^_+|_+$/g, '');
-        }
-        break;
-      case 'kebabcase':
-        if (typeof result === 'string') {
-          result = result
-            .trim()
-            .replace(/([a-z])([A-Z])/g, '$1-$2')
-            .replace(/[^a-zA-Z0-9]+/g, '-')
-            .toLowerCase()
-            .replace(/^-+|-+$/g, '');
-        }
-        break;
-      case 'titlecase':
-        if (typeof result === 'string') {
-          result = result
-            .trim()
-            .replace(/([a-z])([A-Z])/g, '$1 $2')
-            .replace(/[^a-zA-Z0-9]+/g, ' ')
-            .replace(/\b([a-z])/g, (_, chr) => chr.toUpperCase())
-            .trim();
-        }
-        break;
-      case 'json':
-        result = JSON.stringify(result, null, 2);
-        break;
-      case 'join':
-        if (Array.isArray(result)) result = result.join(', ');
-        break;
-      case 'unique':
-        if (Array.isArray(result)) result = Array.from(new Set(result));
-        break;
-      case 'first':
-        if (Array.isArray(result) || typeof result === 'string') {
-          result = result.length > 0 ? result[0] : undefined;
-        }
-        break;
-      case 'last':
-        if (Array.isArray(result) || typeof result === 'string') {
-          result = result.length > 0 ? result[result.length - 1] : undefined;
-        }
-        break;
-      case 'length':
-        if (Array.isArray(result) || typeof result === 'string') result = result.length;
-        break;
-      case 'plural':
-        if (typeof result === 'number') result = result === 1 ? '' : 's';
-        break;
-      case 'round':
-        if (typeof result === 'number') result = Math.round(result);
-        break;
-      case 'floor':
-        if (typeof result === 'number') result = Math.floor(result);
-        break;
-      case 'ceil':
-        if (typeof result === 'number') result = Math.ceil(result);
-        break;
-      case 'abs':
-        if (typeof result === 'number') result = Math.abs(result);
-        break;
-      case 'reverse':
-        if (Array.isArray(result)) {
-          result = [...result].reverse();
-        } else if (typeof result === 'string') {
-          result = [...result].reverse().join('');
-        }
-        break;
-      case 'sort':
-        if (Array.isArray(result)) {
-          result = [...result].sort();
-        }
-        break;
-      case 'compact':
-        if (Array.isArray(result)) {
-          result = result.filter((item) => item !== null && item !== undefined && item !== '');
-        }
-        break;
-      case 'sum':
-        if (Array.isArray(result)) {
-          result = result.reduce((acc, item) => {
-            const num = Number(item);
-            return Number.isNaN(num) ? acc : acc + num;
-          }, 0);
-        }
-        break;
-      case 'avg':
-        if (Array.isArray(result)) {
-          const nums = result.map(Number).filter((n) => !Number.isNaN(n));
-          result = nums.length > 0 ? nums.reduce((a, b) => a + b, 0) / nums.length : 0;
-        }
-        break;
-    }
-  }
-  return result;
+	let result = value;
+	for (const t of transforms) {
+		const transform = t.trim().toLowerCase();
+		switch (transform) {
+			case "upper":
+			case "uppercase":
+				if (typeof result === "string") result = result.toUpperCase();
+				break;
+			case "lower":
+			case "lowercase":
+				if (typeof result === "string") result = result.toLowerCase();
+				break;
+			case "capitalize":
+				if (typeof result === "string")
+					result = result.charAt(0).toUpperCase() + result.slice(1);
+				break;
+			case "trim":
+				if (typeof result === "string") result = result.trim();
+				break;
+			case "camelcase":
+				if (typeof result === "string") {
+					result = result
+						.trim()
+						.replace(/[^a-zA-Z0-9]+(.)/g, (_, chr) => chr.toUpperCase())
+						.replace(/[^a-zA-Z0-9]+$/, "")
+						.replace(/^[A-Z]/, (chr) => chr.toLowerCase());
+				}
+				break;
+			case "pascalcase":
+				if (typeof result === "string") {
+					result = result
+						.trim()
+						.replace(/[^a-zA-Z0-9]+(.)/g, (_, chr) => chr.toUpperCase())
+						.replace(/[^a-zA-Z0-9]+$/, "")
+						.replace(/^[a-z]/, (chr) => chr.toUpperCase());
+				}
+				break;
+			case "snakecase":
+				if (typeof result === "string") {
+					result = result
+						.trim()
+						.replace(/([a-z])([A-Z])/g, "$1_$2")
+						.replace(/[^a-zA-Z0-9]+/g, "_")
+						.toLowerCase()
+						.replace(/^_+|_+$/g, "");
+				}
+				break;
+			case "kebabcase":
+				if (typeof result === "string") {
+					result = result
+						.trim()
+						.replace(/([a-z])([A-Z])/g, "$1-$2")
+						.replace(/[^a-zA-Z0-9]+/g, "-")
+						.toLowerCase()
+						.replace(/^-+|-+$/g, "");
+				}
+				break;
+			case "titlecase":
+				if (typeof result === "string") {
+					result = result
+						.trim()
+						.replace(/([a-z])([A-Z])/g, "$1 $2")
+						.replace(/[^a-zA-Z0-9]+/g, " ")
+						.replace(/\b([a-z])/g, (_, chr) => chr.toUpperCase())
+						.trim();
+				}
+				break;
+			case "json":
+				result = JSON.stringify(result, null, 2);
+				break;
+			case "join":
+				if (Array.isArray(result)) result = result.join(", ");
+				break;
+			case "unique":
+				if (Array.isArray(result)) result = Array.from(new Set(result));
+				break;
+			case "first":
+				if (Array.isArray(result) || typeof result === "string") {
+					result = result.length > 0 ? result[0] : undefined;
+				}
+				break;
+			case "last":
+				if (Array.isArray(result) || typeof result === "string") {
+					result = result.length > 0 ? result[result.length - 1] : undefined;
+				}
+				break;
+			case "length":
+				if (Array.isArray(result) || typeof result === "string")
+					result = result.length;
+				break;
+			case "plural":
+				if (typeof result === "number") result = result === 1 ? "" : "s";
+				break;
+			case "round":
+				if (typeof result === "number") result = Math.round(result);
+				break;
+			case "floor":
+				if (typeof result === "number") result = Math.floor(result);
+				break;
+			case "ceil":
+				if (typeof result === "number") result = Math.ceil(result);
+				break;
+			case "abs":
+				if (typeof result === "number") result = Math.abs(result);
+				break;
+			case "reverse":
+				if (Array.isArray(result)) {
+					result = [...result].reverse();
+				} else if (typeof result === "string") {
+					result = [...result].reverse().join("");
+				}
+				break;
+			case "sort":
+				if (Array.isArray(result)) {
+					result = [...result].sort();
+				}
+				break;
+			case "compact":
+				if (Array.isArray(result)) {
+					result = result.filter(
+						(item) => item !== null && item !== undefined && item !== "",
+					);
+				}
+				break;
+			case "sum":
+				if (Array.isArray(result)) {
+					result = result.reduce((acc, item) => {
+						const num = Number(item);
+						return Number.isNaN(num) ? acc : acc + num;
+					}, 0);
+				}
+				break;
+			case "avg":
+				if (Array.isArray(result)) {
+					const nums = result.map(Number).filter((n) => !Number.isNaN(n));
+					result =
+						nums.length > 0 ? nums.reduce((a, b) => a + b, 0) / nums.length : 0;
+				}
+				break;
+			case "min":
+				if (Array.isArray(result)) {
+					const nums = result.map(Number).filter((n) => !Number.isNaN(n));
+					result = nums.length > 0 ? Math.min(...nums) : undefined;
+				}
+				break;
+			case "max":
+				if (Array.isArray(result)) {
+					const nums = result.map(Number).filter((n) => !Number.isNaN(n));
+					result = nums.length > 0 ? Math.max(...nums) : undefined;
+				}
+				break;
+			case "empty":
+				result =
+					result === null ||
+					result === undefined ||
+					result === "" ||
+					(Array.isArray(result) && result.length === 0);
+				break;
+			case "notempty":
+				result = !(
+					result === null ||
+					result === undefined ||
+					result === "" ||
+					(Array.isArray(result) && result.length === 0)
+				);
+				break;
+			case "boolean":
+				result = Boolean(result);
+				break;
+		}
+	}
+	return result;
 }

--- a/packages/core/tests/index.test.ts
+++ b/packages/core/tests/index.test.ts
@@ -1,183 +1,248 @@
-import { describe, it, expect } from 'vitest';
-import { applyTransforms } from '../src/index';
+import { describe, expect, it } from "vitest";
+import { applyTransforms } from "../src/index";
 
-describe('applyTransforms', () => {
-  it('should handle upper and uppercase', () => {
-    expect(applyTransforms('hello', ['upper'])).toBe('HELLO');
-    expect(applyTransforms('hello', ['uppercase'])).toBe('HELLO');
-  });
+describe("applyTransforms", () => {
+	it("should handle upper and uppercase", () => {
+		expect(applyTransforms("hello", ["upper"])).toBe("HELLO");
+		expect(applyTransforms("hello", ["uppercase"])).toBe("HELLO");
+	});
 
-  it('should handle lower and lowercase', () => {
-    expect(applyTransforms('HELLO', ['lower'])).toBe('hello');
-    expect(applyTransforms('HELLO', ['lowercase'])).toBe('hello');
-  });
+	it("should handle lower and lowercase", () => {
+		expect(applyTransforms("HELLO", ["lower"])).toBe("hello");
+		expect(applyTransforms("HELLO", ["lowercase"])).toBe("hello");
+	});
 
-  it('should handle capitalize', () => {
-    expect(applyTransforms('hello', ['capitalize'])).toBe('Hello');
-  });
+	it("should handle capitalize", () => {
+		expect(applyTransforms("hello", ["capitalize"])).toBe("Hello");
+	});
 
-  it('should handle trim', () => {
-    expect(applyTransforms('  hello  ', ['trim'])).toBe('hello');
-  });
+	it("should handle trim", () => {
+		expect(applyTransforms("  hello  ", ["trim"])).toBe("hello");
+	});
 
-  it('should handle camelcase', () => {
-    expect(applyTransforms('hello world', ['camelcase'])).toBe('helloWorld');
-    expect(applyTransforms('Hello World', ['camelcase'])).toBe('helloWorld');
-    expect(applyTransforms('hello-world', ['camelcase'])).toBe('helloWorld');
-    expect(applyTransforms('hello_world', ['camelcase'])).toBe('helloWorld');
-  });
+	it("should handle camelcase", () => {
+		expect(applyTransforms("hello world", ["camelcase"])).toBe("helloWorld");
+		expect(applyTransforms("Hello World", ["camelcase"])).toBe("helloWorld");
+		expect(applyTransforms("hello-world", ["camelcase"])).toBe("helloWorld");
+		expect(applyTransforms("hello_world", ["camelcase"])).toBe("helloWorld");
+	});
 
-  it('should handle pascalcase', () => {
-    expect(applyTransforms('hello world', ['pascalcase'])).toBe('HelloWorld');
-    expect(applyTransforms('hello-world', ['pascalcase'])).toBe('HelloWorld');
-    expect(applyTransforms('hello_world', ['pascalcase'])).toBe('HelloWorld');
-  });
+	it("should handle pascalcase", () => {
+		expect(applyTransforms("hello world", ["pascalcase"])).toBe("HelloWorld");
+		expect(applyTransforms("hello-world", ["pascalcase"])).toBe("HelloWorld");
+		expect(applyTransforms("hello_world", ["pascalcase"])).toBe("HelloWorld");
+	});
 
-  it('should handle snakecase', () => {
-    expect(applyTransforms('helloWorld', ['snakecase'])).toBe('hello_world');
-    expect(applyTransforms('hello world', ['snakecase'])).toBe('hello_world');
-    expect(applyTransforms('hello-world', ['snakecase'])).toBe('hello_world');
-  });
+	it("should handle snakecase", () => {
+		expect(applyTransforms("helloWorld", ["snakecase"])).toBe("hello_world");
+		expect(applyTransforms("hello world", ["snakecase"])).toBe("hello_world");
+		expect(applyTransforms("hello-world", ["snakecase"])).toBe("hello_world");
+	});
 
-  it('should handle kebabcase', () => {
-    expect(applyTransforms('helloWorld', ['kebabcase'])).toBe('hello-world');
-    expect(applyTransforms('hello world', ['kebabcase'])).toBe('hello-world');
-    expect(applyTransforms('hello_world', ['kebabcase'])).toBe('hello-world');
-  });
+	it("should handle kebabcase", () => {
+		expect(applyTransforms("helloWorld", ["kebabcase"])).toBe("hello-world");
+		expect(applyTransforms("hello world", ["kebabcase"])).toBe("hello-world");
+		expect(applyTransforms("hello_world", ["kebabcase"])).toBe("hello-world");
+	});
 
-  it('should handle titlecase', () => {
-    expect(applyTransforms('hello world', ['titlecase'])).toBe('Hello World');
-    expect(applyTransforms('hello-world', ['titlecase'])).toBe('Hello World');
-    expect(applyTransforms('hello_world', ['titlecase'])).toBe('Hello World');
-    expect(applyTransforms('helloWorld', ['titlecase'])).toBe('Hello World');
-    expect(applyTransforms('  hello   world  ', ['titlecase'])).toBe('Hello World');
-  });
+	it("should handle titlecase", () => {
+		expect(applyTransforms("hello world", ["titlecase"])).toBe("Hello World");
+		expect(applyTransforms("hello-world", ["titlecase"])).toBe("Hello World");
+		expect(applyTransforms("hello_world", ["titlecase"])).toBe("Hello World");
+		expect(applyTransforms("helloWorld", ["titlecase"])).toBe("Hello World");
+		expect(applyTransforms("  hello   world  ", ["titlecase"])).toBe(
+			"Hello World",
+		);
+	});
 
-  it('should handle chained transformations', () => {
-    expect(applyTransforms('  hello world  ', ['trim', 'camelcase', 'capitalize'])).toBe('HelloWorld');
-  });
+	it("should handle chained transformations", () => {
+		expect(
+			applyTransforms("  hello world  ", ["trim", "camelcase", "capitalize"]),
+		).toBe("HelloWorld");
+	});
 
-  it('should return original value for non-strings when using string-only transforms', () => {
-    expect(applyTransforms(123, ['upper'])).toBe(123);
-    expect(applyTransforms(null, ['upper'])).toBe(null);
-  });
+	it("should return original value for non-strings when using string-only transforms", () => {
+		expect(applyTransforms(123, ["upper"])).toBe(123);
+		expect(applyTransforms(null, ["upper"])).toBe(null);
+	});
 
-  it('should handle json transformation', () => {
-    const obj = { a: 1, b: 'hello' };
-    expect(applyTransforms(obj, ['json'])).toBe(JSON.stringify(obj, null, 2));
-    expect(applyTransforms([1, 2, 3], ['json'])).toBe(JSON.stringify([1, 2, 3], null, 2));
-    expect(applyTransforms('hello', ['json'])).toBe('"hello"');
-  });
+	it("should handle json transformation", () => {
+		const obj = { a: 1, b: "hello" };
+		expect(applyTransforms(obj, ["json"])).toBe(JSON.stringify(obj, null, 2));
+		expect(applyTransforms([1, 2, 3], ["json"])).toBe(
+			JSON.stringify([1, 2, 3], null, 2),
+		);
+		expect(applyTransforms("hello", ["json"])).toBe('"hello"');
+	});
 
-  it('should handle chained transformations with json', () => {
-    const obj = { name: 'spark' };
-    // json -> uppercase (no effect as json returns string, but uppercase works on it)
-    const jsonStr = JSON.stringify(obj, null, 2);
-    expect(applyTransforms(obj, ['json', 'uppercase'])).toBe(jsonStr.toUpperCase());
-  });
+	it("should handle chained transformations with json", () => {
+		const obj = { name: "spark" };
+		// json -> uppercase (no effect as json returns string, but uppercase works on it)
+		const jsonStr = JSON.stringify(obj, null, 2);
+		expect(applyTransforms(obj, ["json", "uppercase"])).toBe(
+			jsonStr.toUpperCase(),
+		);
+	});
 
-  it('should handle join transformation', () => {
-    expect(applyTransforms(['a', 'b', 'c'], ['join'])).toBe('a, b, c');
-    expect(applyTransforms([], ['join'])).toBe('');
-    expect(applyTransforms('not an array', ['join'])).toBe('not an array');
-  });
+	it("should handle join transformation", () => {
+		expect(applyTransforms(["a", "b", "c"], ["join"])).toBe("a, b, c");
+		expect(applyTransforms([], ["join"])).toBe("");
+		expect(applyTransforms("not an array", ["join"])).toBe("not an array");
+	});
 
-  it('should handle unique transformation', () => {
-    expect(applyTransforms(['a', 'b', 'a', 'c', 'b'], ['unique'])).toEqual(['a', 'b', 'c']);
-    expect(applyTransforms([1, 2, 1, 3, 2], ['unique'])).toEqual([1, 2, 3]);
-    expect(applyTransforms([], ['unique'])).toEqual([]);
-    expect(applyTransforms('not an array', ['unique'])).toBe('not an array');
-  });
+	it("should handle unique transformation", () => {
+		expect(applyTransforms(["a", "b", "a", "c", "b"], ["unique"])).toEqual([
+			"a",
+			"b",
+			"c",
+		]);
+		expect(applyTransforms([1, 2, 1, 3, 2], ["unique"])).toEqual([1, 2, 3]);
+		expect(applyTransforms([], ["unique"])).toEqual([]);
+		expect(applyTransforms("not an array", ["unique"])).toBe("not an array");
+	});
 
-  it('should handle first transformation', () => {
-    expect(applyTransforms(['a', 'b', 'c'], ['first'])).toBe('a');
-    expect(applyTransforms('hello', ['first'])).toBe('h');
-    expect(applyTransforms([], ['first'])).toBeUndefined();
-    expect(applyTransforms('', ['first'])).toBeUndefined();
-  });
+	it("should handle first transformation", () => {
+		expect(applyTransforms(["a", "b", "c"], ["first"])).toBe("a");
+		expect(applyTransforms("hello", ["first"])).toBe("h");
+		expect(applyTransforms([], ["first"])).toBeUndefined();
+		expect(applyTransforms("", ["first"])).toBeUndefined();
+	});
 
-  it('should handle last transformation', () => {
-    expect(applyTransforms(['a', 'b', 'c'], ['last'])).toBe('c');
-    expect(applyTransforms('hello', ['last'])).toBe('o');
-    expect(applyTransforms([], ['last'])).toBeUndefined();
-    expect(applyTransforms('', ['last'])).toBeUndefined();
-  });
+	it("should handle last transformation", () => {
+		expect(applyTransforms(["a", "b", "c"], ["last"])).toBe("c");
+		expect(applyTransforms("hello", ["last"])).toBe("o");
+		expect(applyTransforms([], ["last"])).toBeUndefined();
+		expect(applyTransforms("", ["last"])).toBeUndefined();
+	});
 
-  it('should handle length transformation', () => {
-    expect(applyTransforms(['a', 'b', 'c'], ['length'])).toBe(3);
-    expect(applyTransforms('hello', ['length'])).toBe(5);
-    expect(applyTransforms([], ['length'])).toBe(0);
-    expect(applyTransforms('', ['length'])).toBe(0);
-  });
+	it("should handle length transformation", () => {
+		expect(applyTransforms(["a", "b", "c"], ["length"])).toBe(3);
+		expect(applyTransforms("hello", ["length"])).toBe(5);
+		expect(applyTransforms([], ["length"])).toBe(0);
+		expect(applyTransforms("", ["length"])).toBe(0);
+	});
 
-  it('should handle plural transformation', () => {
-    expect(applyTransforms(0, ['plural'])).toBe('s');
-    expect(applyTransforms(1, ['plural'])).toBe('');
-    expect(applyTransforms(2, ['plural'])).toBe('s');
-    expect(applyTransforms(1.5, ['plural'])).toBe('s');
-    expect(applyTransforms('not a number', ['plural'])).toBe('not a number');
-  });
+	it("should handle plural transformation", () => {
+		expect(applyTransforms(0, ["plural"])).toBe("s");
+		expect(applyTransforms(1, ["plural"])).toBe("");
+		expect(applyTransforms(2, ["plural"])).toBe("s");
+		expect(applyTransforms(1.5, ["plural"])).toBe("s");
+		expect(applyTransforms("not a number", ["plural"])).toBe("not a number");
+	});
 
-  it('should handle round transformation', () => {
-    expect(applyTransforms(1.4, ['round'])).toBe(1);
-    expect(applyTransforms(1.5, ['round'])).toBe(2);
-    expect(applyTransforms(1.6, ['round'])).toBe(2);
-    expect(applyTransforms(-1.5, ['round'])).toBe(-1); // Math.round(-1.5) is -1
-    expect(applyTransforms('not a number', ['round'])).toBe('not a number');
-  });
+	it("should handle round transformation", () => {
+		expect(applyTransforms(1.4, ["round"])).toBe(1);
+		expect(applyTransforms(1.5, ["round"])).toBe(2);
+		expect(applyTransforms(1.6, ["round"])).toBe(2);
+		expect(applyTransforms(-1.5, ["round"])).toBe(-1); // Math.round(-1.5) is -1
+		expect(applyTransforms("not a number", ["round"])).toBe("not a number");
+	});
 
-  it('should handle floor transformation', () => {
-    expect(applyTransforms(1.9, ['floor'])).toBe(1);
-    expect(applyTransforms(-1.1, ['floor'])).toBe(-2);
-    expect(applyTransforms('not a number', ['floor'])).toBe('not a number');
-  });
+	it("should handle floor transformation", () => {
+		expect(applyTransforms(1.9, ["floor"])).toBe(1);
+		expect(applyTransforms(-1.1, ["floor"])).toBe(-2);
+		expect(applyTransforms("not a number", ["floor"])).toBe("not a number");
+	});
 
-  it('should handle ceil transformation', () => {
-    expect(applyTransforms(1.1, ['ceil'])).toBe(2);
-    expect(applyTransforms(-1.9, ['ceil'])).toBe(-1);
-    expect(applyTransforms('not a number', ['ceil'])).toBe('not a number');
-  });
+	it("should handle ceil transformation", () => {
+		expect(applyTransforms(1.1, ["ceil"])).toBe(2);
+		expect(applyTransforms(-1.9, ["ceil"])).toBe(-1);
+		expect(applyTransforms("not a number", ["ceil"])).toBe("not a number");
+	});
 
-  it('should handle abs transformation', () => {
-    expect(applyTransforms(-5, ['abs'])).toBe(5);
-    expect(applyTransforms(5, ['abs'])).toBe(5);
-    expect(applyTransforms('not a number', ['abs'])).toBe('not a number');
-  });
+	it("should handle abs transformation", () => {
+		expect(applyTransforms(-5, ["abs"])).toBe(5);
+		expect(applyTransforms(5, ["abs"])).toBe(5);
+		expect(applyTransforms("not a number", ["abs"])).toBe("not a number");
+	});
 
-  it('should handle reverse transformation', () => {
-    expect(applyTransforms(['a', 'b', 'c'], ['reverse'])).toEqual(['c', 'b', 'a']);
-    expect(applyTransforms('hello', ['reverse'])).toBe('olleh');
-    expect(applyTransforms([], ['reverse'])).toEqual([]);
-    expect(applyTransforms('', ['reverse'])).toBe('');
-    expect(applyTransforms(123, ['reverse'])).toBe(123);
-  });
+	it("should handle reverse transformation", () => {
+		expect(applyTransforms(["a", "b", "c"], ["reverse"])).toEqual([
+			"c",
+			"b",
+			"a",
+		]);
+		expect(applyTransforms("hello", ["reverse"])).toBe("olleh");
+		expect(applyTransforms([], ["reverse"])).toEqual([]);
+		expect(applyTransforms("", ["reverse"])).toBe("");
+		expect(applyTransforms(123, ["reverse"])).toBe(123);
+	});
 
-  it('should handle sort transformation', () => {
-    expect(applyTransforms(['c', 'a', 'b'], ['sort'])).toEqual(['a', 'b', 'c']);
-    expect(applyTransforms([3, 1, 2], ['sort'])).toEqual([1, 2, 3]);
-    expect(applyTransforms([], ['sort'])).toEqual([]);
-    expect(applyTransforms('not an array', ['sort'])).toBe('not an array');
-  });
+	it("should handle sort transformation", () => {
+		expect(applyTransforms(["c", "a", "b"], ["sort"])).toEqual(["a", "b", "c"]);
+		expect(applyTransforms([3, 1, 2], ["sort"])).toEqual([1, 2, 3]);
+		expect(applyTransforms([], ["sort"])).toEqual([]);
+		expect(applyTransforms("not an array", ["sort"])).toBe("not an array");
+	});
 
-  it('should handle compact transformation', () => {
-    expect(applyTransforms(['a', '', null, 'b', undefined, 'c'], ['compact'])).toEqual(['a', 'b', 'c']);
-    expect(applyTransforms([], ['compact'])).toEqual([]);
-    expect(applyTransforms('not an array', ['compact'])).toBe('not an array');
-  });
+	it("should handle compact transformation", () => {
+		expect(
+			applyTransforms(["a", "", null, "b", undefined, "c"], ["compact"]),
+		).toEqual(["a", "b", "c"]);
+		expect(applyTransforms([], ["compact"])).toEqual([]);
+		expect(applyTransforms("not an array", ["compact"])).toBe("not an array");
+	});
 
-  it('should handle sum transformation', () => {
-    expect(applyTransforms([1, 2, 3], ['sum'])).toBe(6);
-    expect(applyTransforms(['1', '2', '3'], ['sum'])).toBe(6);
-    expect(applyTransforms([1, 'invalid', 2], ['sum'])).toBe(3);
-    expect(applyTransforms([], ['sum'])).toBe(0);
-    expect(applyTransforms('not an array', ['sum'])).toBe('not an array');
-  });
+	it("should handle sum transformation", () => {
+		expect(applyTransforms([1, 2, 3], ["sum"])).toBe(6);
+		expect(applyTransforms(["1", "2", "3"], ["sum"])).toBe(6);
+		expect(applyTransforms([1, "invalid", 2], ["sum"])).toBe(3);
+		expect(applyTransforms([], ["sum"])).toBe(0);
+		expect(applyTransforms("not an array", ["sum"])).toBe("not an array");
+	});
 
-  it('should handle avg transformation', () => {
-    expect(applyTransforms([2, 4, 6], ['avg'])).toBe(4);
-    expect(applyTransforms(['2', '4', '6'], ['avg'])).toBe(4);
-    expect(applyTransforms([2, 'invalid', 4], ['avg'])).toBe(3);
-    expect(applyTransforms([], ['avg'])).toBe(0);
-    expect(applyTransforms('not an array', ['avg'])).toBe('not an array');
-  });
+	it("should handle avg transformation", () => {
+		expect(applyTransforms([2, 4, 6], ["avg"])).toBe(4);
+		expect(applyTransforms(["2", "4", "6"], ["avg"])).toBe(4);
+		expect(applyTransforms([2, "invalid", 4], ["avg"])).toBe(3);
+		expect(applyTransforms([], ["avg"])).toBe(0);
+		expect(applyTransforms("not an array", ["avg"])).toBe("not an array");
+	});
+
+	it("should handle min transformation", () => {
+		expect(applyTransforms([5, 2, 8, 1], ["min"])).toBe(1);
+		expect(applyTransforms(["10", "2", "30"], ["min"])).toBe(2);
+		expect(applyTransforms([10, "invalid", 5], ["min"])).toBe(5);
+		expect(applyTransforms([], ["min"])).toBeUndefined();
+		expect(applyTransforms("not an array", ["min"])).toBe("not an array");
+	});
+
+	it("should handle max transformation", () => {
+		expect(applyTransforms([5, 2, 8, 1], ["max"])).toBe(8);
+		expect(applyTransforms(["10", "2", "30"], ["max"])).toBe(30);
+		expect(applyTransforms([10, "invalid", 5], ["max"])).toBe(10);
+		expect(applyTransforms([], ["max"])).toBeUndefined();
+		expect(applyTransforms("not an array", ["max"])).toBe("not an array");
+	});
+
+	it("should handle empty transformation", () => {
+		expect(applyTransforms(null, ["empty"])).toBe(true);
+		expect(applyTransforms(undefined, ["empty"])).toBe(true);
+		expect(applyTransforms("", ["empty"])).toBe(true);
+		expect(applyTransforms([], ["empty"])).toBe(true);
+		expect(applyTransforms("hello", ["empty"])).toBe(false);
+		expect(applyTransforms([1], ["empty"])).toBe(false);
+		expect(applyTransforms(0, ["empty"])).toBe(false);
+		expect(applyTransforms(false, ["empty"])).toBe(false);
+	});
+
+	it("should handle notempty transformation", () => {
+		expect(applyTransforms(null, ["notempty"])).toBe(false);
+		expect(applyTransforms(undefined, ["notempty"])).toBe(false);
+		expect(applyTransforms("", ["notempty"])).toBe(false);
+		expect(applyTransforms([], ["notempty"])).toBe(false);
+		expect(applyTransforms("hello", ["notempty"])).toBe(true);
+		expect(applyTransforms([1], ["notempty"])).toBe(true);
+		expect(applyTransforms(0, ["notempty"])).toBe(true);
+		expect(applyTransforms(false, ["notempty"])).toBe(true);
+	});
+
+	it("should handle boolean transformation", () => {
+		expect(applyTransforms(1, ["boolean"])).toBe(true);
+		expect(applyTransforms(0, ["boolean"])).toBe(false);
+		expect(applyTransforms("true", ["boolean"])).toBe(true);
+		expect(applyTransforms("", ["boolean"])).toBe(false);
+		expect(applyTransforms(null, ["boolean"])).toBe(false);
+		expect(applyTransforms([], ["boolean"])).toBe(true); // [].length is 0 but [] is truthy
+	});
 });

--- a/packages/xlsx/README.md
+++ b/packages/xlsx/README.md
@@ -67,7 +67,7 @@ Use `{{path.to.value}}` for values that do not depend on the current row:
 - **Default values**: Use `||` to provide a fallback if a value is missing or null.
   - `{{user.name || N/A}}` -> renders "N/A" if `user.name` is missing or null.
   - `{{user.city || user.backupCity}}` -> tries to resolve `user.backupCity` if `user.city` is not found.
-- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`/`uppercase`, `lower`/`lowercase`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `join`, `unique`, `first`, `last`, `length`, `plural`, `round`, `reverse`, `sort`, `compact`, `sum`, `avg`. You can chain them: `{{title | trim | capitalize}}`.
+- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`/`uppercase`, `lower`/`lowercase`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `join`, `unique`, `first`, `last`, `length`, `plural`, `round`, `reverse`, `sort`, `compact`, `sum`, `avg`, `min`, `max`, `empty`, `notempty`, `boolean`. You can chain them: `{{title | trim | capitalize}}`.
 - If the key (or any intermediate segment) does not exist and no default is provided, the **marker is left as-is**.
 - If the resolved value is `null` or `undefined` and no default is provided, the cell becomes an empty string (`""`).
 


### PR DESCRIPTION
💡 **What:** Added five new micro-transforms to the core interpolation engine: `min`, `max`, `empty`, `notempty`, and `boolean`.

🎯 **Why:** To provide template authors with common spreadsheet-like aggregations (`min`/`max`), easy state validation (`empty`/`notempty`), and explicit type casting (`boolean`) without requiring data preprocessing.

📦 **What it adds:**
- `min`/`max`: Extracts minimum or maximum numeric values from an array.
- `empty`/`notempty`: Checks if a value is null, undefined, empty string, or empty array.
- `boolean`: Explicitly casts any value to a boolean.

🚀 **How to use:**
- `{{ scores | min }}`
- `{{ items | empty || No items found }}`
- `[[ items.$isLast | boolean ]]`

♻️ **Deps Free:** Verified no new dependencies added.

🎨 **Harmony:** Fits perfectly within the existing `applyTransforms` architecture and follows established patterns for numeric and collection transforms.

---
*PR created automatically by Jules for task [17272036568045186489](https://jules.google.com/task/17272036568045186489) started by @galiprandi*