### PR TITLE
⚡ Spark: add empty, notempty, and boolean transforms

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ After interpolation with the data above, the result would be:
 - **Type Preservation**: If the cell contains *only* the `{{key}}` marker, the resulting cell will have the same type as the data (e.g., Number, Date, Boolean).
 - Supports nested paths: `{{user.profile.email}}`.
 - **Default values**: `{{path || fallback}}`. Fallback can be a literal string or another path.
-- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`/`uppercase`, `lower`/`lowercase`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `join`, `unique`, `first`, `last`, `length`, `plural`, `round`, `reverse`, `sort`, `compact`, `sum`, `avg`, `min`, `max`. You can chain them: `{{title | trim | capitalize}}`.
+- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`/`uppercase`, `lower`/`lowercase`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `join`, `unique`, `first`, `last`, `length`, `plural`, `round`, `reverse`, `sort`, `compact`, `sum`, `avg`, `min`, `max`, `empty`, `notempty`, `boolean`. You can chain them: `{{title | trim | capitalize}}`.
 - If the key is missing and no default is provided, the marker remains in the cell as-is.
 - If the value is `null` or `undefined` and no default is provided, the cell becomes empty (`""`).
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Used for static values that appear once in your document (e.g., a customer name,
 - **Nested Paths**: Supports dot notation like `{{user.profile.name}}`.
 - **Missing Data**: If a key is missing, the marker `{{key}}` stays in the cell for easier debugging.
 - **Null Values**: If a value is `null` or `undefined`, the cell is cleared.
-- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`, `lower`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `join`, `unique`, `first`, `last`, `length`, `plural`, `round`, `reverse`, `sort`, `compact`, `sum`, `avg`. You can chain them: `{{title | trim | capitalize}}`.
+- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`, `lower`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `join`, `unique`, `first`, `last`, `length`, `plural`, `round`, `reverse`, `sort`, `compact`, `sum`, `avg`, `min`, `max`, `empty`, `notempty`, `boolean`. You can chain them: `{{title | trim | capitalize}}`.
 
 #### Array-Based Row Expansion: `[[array.key]]`
 Used to repeat an entire row for every item in an array.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -183,6 +183,24 @@ export function applyTransforms(value: any, transforms: string[]): any {
           result = nums.length > 0 ? Math.max(...nums) : undefined;
         }
         break;
+      case 'empty':
+        result =
+          result === null ||
+          result === undefined ||
+          result === '' ||
+          (Array.isArray(result) && result.length === 0);
+        break;
+      case 'notempty':
+        result = !(
+          result === null ||
+          result === undefined ||
+          result === '' ||
+          (Array.isArray(result) && result.length === 0)
+        );
+        break;
+      case 'boolean':
+        result = Boolean(result);
+        break;
     }
   }
   return result;

--- a/packages/core/tests/index.test.ts
+++ b/packages/core/tests/index.test.ts
@@ -198,4 +198,36 @@ describe('applyTransforms', () => {
     expect(applyTransforms(['invalid'], ['max'])).toBeUndefined();
     expect(applyTransforms('not an array', ['max'])).toBe('not an array');
   });
+
+  it('should handle empty transformation', () => {
+    expect(applyTransforms(null, ['empty'])).toBe(true);
+    expect(applyTransforms(undefined, ['empty'])).toBe(true);
+    expect(applyTransforms('', ['empty'])).toBe(true);
+    expect(applyTransforms([], ['empty'])).toBe(true);
+    expect(applyTransforms('hello', ['empty'])).toBe(false);
+    expect(applyTransforms(['a'], ['empty'])).toBe(false);
+    expect(applyTransforms(0, ['empty'])).toBe(false);
+    expect(applyTransforms(false, ['empty'])).toBe(false);
+  });
+
+  it('should handle notempty transformation', () => {
+    expect(applyTransforms(null, ['notempty'])).toBe(false);
+    expect(applyTransforms(undefined, ['notempty'])).toBe(false);
+    expect(applyTransforms('', ['notempty'])).toBe(false);
+    expect(applyTransforms([], ['notempty'])).toBe(false);
+    expect(applyTransforms('hello', ['notempty'])).toBe(true);
+    expect(applyTransforms(['a'], ['notempty'])).toBe(true);
+    expect(applyTransforms(0, ['notempty'])).toBe(true);
+    expect(applyTransforms(false, ['notempty'])).toBe(true);
+  });
+
+  it('should handle boolean transformation', () => {
+    expect(applyTransforms(1, ['boolean'])).toBe(true);
+    expect(applyTransforms(0, ['boolean'])).toBe(false);
+    expect(applyTransforms('hello', ['boolean'])).toBe(true);
+    expect(applyTransforms('', ['boolean'])).toBe(false);
+    expect(applyTransforms(null, ['boolean'])).toBe(false);
+    expect(applyTransforms(undefined, ['boolean'])).toBe(false);
+    expect(applyTransforms([], ['boolean'])).toBe(true); // empty array is truthy in JS
+  });
 });


### PR DESCRIPTION
### 💡 What:
Added three new utility transforms to the core interpolation engine: `empty`, `notempty`, and `boolean`.

### 🎯 Why:
Template authors often need to check if a value exists or cast it to a boolean to drive conditional logic (e.g., using default values or combining with other future features) without preprocessing data in the backend.

### 📦 What it adds:
- `{{ value | empty }}`: Returns `true` if `value` is `null`, `undefined`, `''`, or `[]`.
- `{{ value | notempty }}`: Returns `true` if `value` is NOT empty.
- `{{ value | boolean }}`: Explicitly casts `value` to a `Boolean`.

### 🚀 How to use:
```text
{{ items | empty }} -> true if items is []
{{ items | notempty || No items found }} -> Returns [] if not empty, otherwise "No items found"
{{ status | boolean }} -> true if status is 1, false if 0
```

### ♻️ Deps Free:
Confirmed. Uses only built-in JavaScript/TypeScript functionality.

### 🎨 Harmony:
Follows the existing pattern of micro-transforms in `applyTransforms`. Case-insensitive and type-guarded.

---
*PR created automatically by Jules for task [2822020855979145389](https://jules.google.com/task/2822020855979145389) started by @galiprandi*