### PR TITLE
⚡ Spark: Add initials transform

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ After interpolation with the data above, the result would be:
 - **Type Preservation**: If the cell contains *only* the `{{key}}` marker, the resulting cell will have the same type as the data (e.g., Number, Date, Boolean).
 - Supports nested paths: `{{user.profile.email}}`.
 - **Default values**: `{{path || fallback}}`. Fallback can be a literal string or another path.
-- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`/`uppercase`, `lower`/`lowercase`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `join`, `unique`, `first`, `last`, `length`, `plural`, `round`, `reverse`, `sort`, `compact`, `sum`, `avg`, `min`, `max`, `empty`, `notempty`, `boolean`. You can chain them: `{{title | trim | capitalize}}`.
+- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`/`uppercase`, `lower`/`lowercase`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `initials`, `join`, `unique`, `first`, `last`, `length`, `plural`, `round`, `reverse`, `sort`, `compact`, `sum`, `avg`, `min`, `max`, `empty`, `notempty`, `boolean`. You can chain them: `{{title | trim | capitalize}}`.
 - If the key is missing and no default is provided, the marker remains in the cell as-is.
 - If the value is `null` or `undefined` and no default is provided, the cell becomes empty (`""`).
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Used for static values that appear once in your document (e.g., a customer name,
 - **Nested Paths**: Supports dot notation like `{{user.profile.name}}`.
 - **Missing Data**: If a key is missing, the marker `{{key}}` stays in the cell for easier debugging.
 - **Null Values**: If a value is `null` or `undefined`, the cell is cleared.
-- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`, `lower`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `join`, `unique`, `first`, `last`, `length`, `plural`, `round`, `reverse`, `sort`, `compact`, `sum`, `avg`, `min`, `max`, `empty`, `notempty`, `boolean`. You can chain them: `{{title | trim | capitalize}}`.
+- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`, `lower`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `initials`, `join`, `unique`, `first`, `last`, `length`, `plural`, `round`, `reverse`, `sort`, `compact`, `sum`, `avg`, `min`, `max`, `empty`, `notempty`, `boolean`. You can chain them: `{{title | trim | capitalize}}`.
 
 #### Array-Based Row Expansion: `[[array.key]]`
 Used to repeat an entire row for every item in an array.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -114,6 +114,16 @@ export function applyTransforms(value: any, transforms: string[]): any {
             .trim();
         }
         break;
+      case 'initials':
+        if (typeof result === 'string') {
+          result = result
+            .trim()
+            .split(/\s+/)
+            .filter((word) => word.length > 0)
+            .map((word) => word.charAt(0).toUpperCase())
+            .join('');
+        }
+        break;
       case 'json':
         result = JSON.stringify(result, null, 2);
         break;

--- a/packages/core/tests/index.test.ts
+++ b/packages/core/tests/index.test.ts
@@ -66,6 +66,16 @@ describe('applyTransforms', () => {
     expect(applyTransforms('  hello   world  ', ['titlecase'])).toBe('Hello World');
   });
 
+  it('should handle initials', () => {
+    expect(applyTransforms('John Doe', ['initials'])).toBe('JD');
+    expect(applyTransforms('spark agent', ['initials'])).toBe('SA');
+    expect(applyTransforms('Single', ['initials'])).toBe('S');
+    expect(applyTransforms('  multi   space  ', ['initials'])).toBe('MS');
+    expect(applyTransforms('', ['initials'])).toBe('');
+    expect(applyTransforms(null, ['initials'])).toBe(null);
+    expect(applyTransforms(123, ['initials'])).toBe(123);
+  });
+
   it('should handle chained transformations', () => {
     expect(applyTransforms('  hello world  ', ['trim', 'camelcase', 'capitalize'])).toBe('HelloWorld');
   });


### PR DESCRIPTION
💡 **What:** Added a new `initials` transformation to the `@interpolator/core` package.

🎯 **Why:** Users often need a quick way to generate shorthand representations or avatars from names and titles in documents.

📦 **What it adds:** A new `initials` transform that takes a string, splits it into words, and returns the first character of each word in uppercase (e.g., `"John Doe"` -> `"JD"`).

🚀 **How to use:** `{{ name | initials }}` or `[[ items.name | initials ]]`.

♻️ **Deps Free:** Zero new dependencies added.

🎨 **Harmony:** Follows the existing transformation pattern in the core package and is supported across all interpolators.

---
*PR created automatically by Jules for task [17439847757840572534](https://jules.google.com/task/17439847757840572534) started by @galiprandi*