### PR TITLE
⚡ Spark: Add initials transform and sync docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ After interpolation with the data above, the result would be:
 - **Type Preservation**: If the cell contains *only* the `{{key}}` marker, the resulting cell will have the same type as the data (e.g., Number, Date, Boolean).
 - Supports nested paths: `{{user.profile.email}}`.
 - **Default values**: `{{path || fallback}}`. Fallback can be a literal string or another path.
-- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`/`uppercase`, `lower`/`lowercase`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `join`, `unique`, `first`, `last`, `length`, `plural`, `round`, `reverse`, `sort`, `compact`, `sum`, `avg`, `min`, `max`, `empty`, `notempty`, `boolean`. You can chain them: `{{title | trim | capitalize}}`.
+- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`/`uppercase`, `lower`/`lowercase`, `capitalize`, `trim`, `trimStart`, `trimEnd`, `camelCase`/`camelcase`, `pascalCase`/`pascalcase`, `snakeCase`/`snakecase`, `kebabCase`/`kebabcase`, `titleCase`/`titlecase`, `initials`, `json`, `join`, `unique`, `first`, `last`, `length`, `plural`, `round`, `floor`, `ceil`, `abs`, `reverse`, `sort`, `compact`, `sum`, `avg`, `min`, `max`, `empty`, `notempty`, `boolean`, `keys`, `values`, `lines`, `flat`. You can chain them: `{{title | trim | capitalize}}`.
 - If the key is missing and no default is provided, the marker remains in the cell as-is.
 - If the value is `null` or `undefined` and no default is provided, the cell becomes empty (`""`).
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Used for static values that appear once in your document (e.g., a customer name,
 - **Nested Paths**: Supports dot notation like `{{user.profile.name}}`.
 - **Missing Data**: If a key is missing, the marker `{{key}}` stays in the cell for easier debugging.
 - **Null Values**: If a value is `null` or `undefined`, the cell is cleared.
-- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`, `lower`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `join`, `unique`, `first`, `last`, `length`, `plural`, `round`, `reverse`, `sort`, `compact`, `sum`, `avg`, `min`, `max`, `empty`, `notempty`, `boolean`. You can chain them: `{{title | trim | capitalize}}`.
+- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`, `lower`, `capitalize`, `trim`, `trimStart`, `trimEnd`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `initials`, `json`, `join`, `unique`, `first`, `last`, `length`, `plural`, `round`, `floor`, `ceil`, `abs`, `reverse`, `sort`, `compact`, `sum`, `avg`, `min`, `max`, `empty`, `notempty`, `boolean`, `keys`, `values`, `lines`, `flat`. You can chain them: `{{title | trim | capitalize}}`.
 
 #### Array-Based Row Expansion: `[[array.key]]`
 Used to repeat an entire row for every item in an array.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -114,6 +114,16 @@ export function applyTransforms(value: any, transforms: string[]): any {
             .trim();
         }
         break;
+      case 'initials':
+        if (typeof result === 'string') {
+          result = result
+            .trim()
+            .split(/\s+/)
+            .filter((word) => word.length > 0)
+            .map((word) => [...word][0].toUpperCase())
+            .join('');
+        }
+        break;
       case 'json':
         result = JSON.stringify(result, null, 2);
         break;

--- a/packages/core/tests/index.test.ts
+++ b/packages/core/tests/index.test.ts
@@ -66,6 +66,18 @@ describe('applyTransforms', () => {
     expect(applyTransforms('  hello   world  ', ['titlecase'])).toBe('Hello World');
   });
 
+  it('should handle initials', () => {
+    expect(applyTransforms('hello world', ['initials'])).toBe('HW');
+    expect(applyTransforms('  John  Doe  ', ['initials'])).toBe('JD');
+    expect(applyTransforms('spark agent', ['initials'])).toBe('SA');
+    expect(applyTransforms('spark', ['initials'])).toBe('S');
+    expect(applyTransforms('', ['initials'])).toBe('');
+    expect(applyTransforms('  ', ['initials'])).toBe('');
+    expect(applyTransforms('multiple   spaces between words', ['initials'])).toBe('MSBW');
+    expect(applyTransforms('unicode 💩 test', ['initials'])).toBe('U💩T');
+    expect(applyTransforms('123 456', ['initials'])).toBe('14');
+  });
+
   it('should handle chained transformations', () => {
     expect(applyTransforms('  hello world  ', ['trim', 'camelcase', 'capitalize'])).toBe('HelloWorld');
   });


### PR DESCRIPTION
I have implemented a new `initials` transform in the `@interpolator/core` package. This transform allows users to extract the first letter of each word in a string, which is useful for creating avatars, compact labels, or references.

The implementation is Unicode-safe and handles multiple spaces between words gracefully.

Additionally, I have updated the documentation in `README.md` and `AGENTS.md` to include all currently supported transforms in the library, ensuring that template authors have a complete reference of the available powerful features.

**Key changes:**
- Added `initials` case to `applyTransforms` in `packages/core/src/index.ts`.
- Added unit tests for `initials` in `packages/core/tests/index.test.ts`.
- Updated `README.md` and `AGENTS.md` with missing transform documentation.

**Usage example:**
`{{ name | initials }}` with `{ name: 'Spark Agent' }` results in `SA`.
`{{ emoji_name | initials }}` with `{ emoji_name: 'Unicode 💩 Test' }` results in `U💩T`.

All tests passed successfully.

---
*PR created automatically by Jules for task [17705930562945904423](https://jules.google.com/task/17705930562945904423) started by @galiprandi*