### PR TITLE
⚡ Spark: Add initials transform

### DIFF
--- a/.axioma/spark.md
+++ b/.axioma/spark.md
@@ -68,6 +68,10 @@
 **Learning:** When implementing numeric aggregations like `min` and `max`, returning `undefined` for empty or non-numeric collections is more accurate than defaulting to `0`. This allows template authors to use default values (e.g., `{{ items | min || N/A }}`) to handle missing data explicitly.
 **Pattern:** Prefer `undefined` over fallback values for collection reductions when the identity element (like 0 for sum) could be misinterpreted as a valid result from the data.
 
+## 2026-07-20 - [Unicode-Safe String Transforms]
+**Learning:** When extracting characters from strings (like for an `initials` transform), standard indexing (`str[0]`) can break on Unicode surrogate pairs like emojis. Using the spread operator (`[...str][0]`) ensures that the transform is robust and "future-proof" for internationalized data.
+**Pattern:** Always use Unicode-aware character access in string utilities to maintain the "high-quality, dependency-free" standard of the library.
+
 ## 2026-07-15 - [Object and Array Manipulation Transforms]
 **Learning:** Providing basic object introspection (`keys`, `values`) and array manipulation (`flat`) transforms allows users to handle more complex data structures directly in templates. Updating `length` to support objects makes the API more consistent across different data types.
 **Pattern:** Extend core utilities to support both arrays and objects where it makes sense (like `length`), and provide specific transforms for type-specific operations that follow standard JavaScript behavior.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,239 +2,270 @@
 // - Marker parser
 // - Nested path resolver
 // - Common types
-export function parseMarkers(template: string): Array<{ type: 'interpolation' | 'array'; path: string; full: string }> {
-  const regex = /(\{\{|\[\[)\s*([^\]}]+)\s*(\}\}|\]\])/g;
-  const matches: Array<{ type: 'interpolation' | 'array'; path: string; full: string }> = [];
-  let match;
+export function parseMarkers(
+	template: string,
+): Array<{ type: "interpolation" | "array"; path: string; full: string }> {
+	const regex = /(\{\{|\[\[)\s*([^\]}]+)\s*(\}\}|\]\])/g;
+	const matches: Array<{
+		type: "interpolation" | "array";
+		path: string;
+		full: string;
+	}> = [];
+	let match;
 
-  while ((match = regex.exec(template)) !== null) {
-    const [full, open, path, close] = match;
-    matches.push({
-      type: open === '{{' ? 'interpolation' : 'array',
-      path,
-      full
-    });
-  }
+	while ((match = regex.exec(template)) !== null) {
+		const [full, open, path, close] = match;
+		matches.push({
+			type: open === "{{" ? "interpolation" : "array",
+			path,
+			full,
+		});
+	}
 
-  return matches;
+	return matches;
 }
 
-export function resolvePath(obj: any, path: string): { found: boolean; value: any } {
-  const keys = path.split('.');
-  let current = obj;
+export function resolvePath(
+	obj: any,
+	path: string,
+): { found: boolean; value: any } {
+	const keys = path.split(".");
+	let current = obj;
 
-  for (const key of keys) {
-    if (current == null || typeof current !== 'object') {
-      return { found: false, value: undefined };
-    }
-    if (!(key in current)) {
-      return { found: false, value: undefined };
-    }
-    current = current[key];
-  }
+	for (const key of keys) {
+		if (current == null || typeof current !== "object") {
+			return { found: false, value: undefined };
+		}
+		if (!(key in current)) {
+			return { found: false, value: undefined };
+		}
+		current = current[key];
+	}
 
-  return { found: true, value: current };
+	return { found: true, value: current };
 }
 
 export function applyTransforms(value: any, transforms: string[]): any {
-  let result = value;
-  for (const t of transforms) {
-    const transform = t.trim().toLowerCase();
-    switch (transform) {
-      case 'upper':
-      case 'uppercase':
-        if (typeof result === 'string') result = result.toUpperCase();
-        break;
-      case 'lower':
-      case 'lowercase':
-        if (typeof result === 'string') result = result.toLowerCase();
-        break;
-      case 'capitalize':
-        if (typeof result === 'string') result = result.charAt(0).toUpperCase() + result.slice(1);
-        break;
-      case 'trim':
-        if (typeof result === 'string') result = result.trim();
-        break;
-      case 'trimstart':
-        if (typeof result === 'string') result = result.trimStart();
-        break;
-      case 'trimend':
-        if (typeof result === 'string') result = result.trimEnd();
-        break;
-      case 'camel':
-      case 'camelcase':
-        if (typeof result === 'string') {
-          result = result
-            .trim()
-            .replace(/[^a-zA-Z0-9]+(.)/g, (_, chr) => chr.toUpperCase())
-            .replace(/[^a-zA-Z0-9]+$/, '')
-            .replace(/^[A-Z]/, (chr) => chr.toLowerCase());
-        }
-        break;
-      case 'pascal':
-      case 'pascalcase':
-        if (typeof result === 'string') {
-          result = result
-            .trim()
-            .replace(/[^a-zA-Z0-9]+(.)/g, (_, chr) => chr.toUpperCase())
-            .replace(/[^a-zA-Z0-9]+$/, '')
-            .replace(/^[a-z]/, (chr) => chr.toUpperCase());
-        }
-        break;
-      case 'snake':
-      case 'snakecase':
-        if (typeof result === 'string') {
-          result = result
-            .trim()
-            .replace(/([a-z])([A-Z])/g, '$1_$2')
-            .replace(/[^a-zA-Z0-9]+/g, '_')
-            .toLowerCase()
-            .replace(/^_+|_+$/g, '');
-        }
-        break;
-      case 'kebab':
-      case 'kebabcase':
-        if (typeof result === 'string') {
-          result = result
-            .trim()
-            .replace(/([a-z])([A-Z])/g, '$1-$2')
-            .replace(/[^a-zA-Z0-9]+/g, '-')
-            .toLowerCase()
-            .replace(/^-+|-+$/g, '');
-        }
-        break;
-      case 'title':
-      case 'titlecase':
-        if (typeof result === 'string') {
-          result = result
-            .trim()
-            .replace(/([a-z])([A-Z])/g, '$1 $2')
-            .replace(/[^a-zA-Z0-9]+/g, ' ')
-            .replace(/\b([a-z])/g, (_, chr) => chr.toUpperCase())
-            .trim();
-        }
-        break;
-      case 'json':
-        result = JSON.stringify(result, null, 2);
-        break;
-      case 'lines':
-        if (typeof result === 'string') result = result.split(/\r?\n/);
-        break;
-      case 'join':
-        if (Array.isArray(result)) result = result.join(', ');
-        break;
-      case 'unique':
-        if (Array.isArray(result)) result = Array.from(new Set(result));
-        break;
-      case 'first':
-        if (Array.isArray(result) || typeof result === 'string') {
-          result = result.length > 0 ? result[0] : undefined;
-        }
-        break;
-      case 'last':
-        if (Array.isArray(result) || typeof result === 'string') {
-          result = result.length > 0 ? result[result.length - 1] : undefined;
-        }
-        break;
-      case 'length':
-        if (Array.isArray(result) || typeof result === 'string') {
-          result = result.length;
-        } else if (result != null && typeof result === 'object') {
-          result = Object.keys(result).length;
-        }
-        break;
-      case 'keys':
-        if (result != null && typeof result === 'object' && !Array.isArray(result)) {
-          result = Object.keys(result);
-        }
-        break;
-      case 'values':
-        if (result != null && typeof result === 'object' && !Array.isArray(result)) {
-          result = Object.values(result);
-        }
-        break;
-      case 'flat':
-        if (Array.isArray(result)) {
-          result = result.flat();
-        }
-        break;
-      case 'plural':
-        if (typeof result === 'number') result = result === 1 ? '' : 's';
-        break;
-      case 'round':
-        if (typeof result === 'number') result = Math.round(result);
-        break;
-      case 'floor':
-        if (typeof result === 'number') result = Math.floor(result);
-        break;
-      case 'ceil':
-        if (typeof result === 'number') result = Math.ceil(result);
-        break;
-      case 'abs':
-        if (typeof result === 'number') result = Math.abs(result);
-        break;
-      case 'reverse':
-        if (Array.isArray(result)) {
-          result = [...result].reverse();
-        } else if (typeof result === 'string') {
-          result = [...result].reverse().join('');
-        }
-        break;
-      case 'sort':
-        if (Array.isArray(result)) {
-          result = [...result].sort();
-        }
-        break;
-      case 'compact':
-        if (Array.isArray(result)) {
-          result = result.filter((item) => item !== null && item !== undefined && item !== '');
-        }
-        break;
-      case 'sum':
-        if (Array.isArray(result)) {
-          result = result.reduce((acc, item) => {
-            const num = Number(item);
-            return Number.isNaN(num) ? acc : acc + num;
-          }, 0);
-        }
-        break;
-      case 'avg':
-        if (Array.isArray(result)) {
-          const nums = result.map(Number).filter((n) => !Number.isNaN(n));
-          result = nums.length > 0 ? nums.reduce((a, b) => a + b, 0) / nums.length : 0;
-        }
-        break;
-      case 'min':
-        if (Array.isArray(result)) {
-          const nums = result.map(Number).filter((n) => !Number.isNaN(n));
-          result = nums.length > 0 ? Math.min(...nums) : undefined;
-        }
-        break;
-      case 'max':
-        if (Array.isArray(result)) {
-          const nums = result.map(Number).filter((n) => !Number.isNaN(n));
-          result = nums.length > 0 ? Math.max(...nums) : undefined;
-        }
-        break;
-      case 'empty':
-        result =
-          result === null ||
-          result === undefined ||
-          result === '' ||
-          (Array.isArray(result) && result.length === 0);
-        break;
-      case 'notempty':
-        result = !(
-          result === null ||
-          result === undefined ||
-          result === '' ||
-          (Array.isArray(result) && result.length === 0)
-        );
-        break;
-      case 'boolean':
-        result = Boolean(result);
-        break;
-    }
-  }
-  return result;
+	let result = value;
+	for (const t of transforms) {
+		const transform = t.trim().toLowerCase();
+		switch (transform) {
+			case "upper":
+			case "uppercase":
+				if (typeof result === "string") result = result.toUpperCase();
+				break;
+			case "lower":
+			case "lowercase":
+				if (typeof result === "string") result = result.toLowerCase();
+				break;
+			case "capitalize":
+				if (typeof result === "string")
+					result = result.charAt(0).toUpperCase() + result.slice(1);
+				break;
+			case "trim":
+				if (typeof result === "string") result = result.trim();
+				break;
+			case "trimstart":
+				if (typeof result === "string") result = result.trimStart();
+				break;
+			case "trimend":
+				if (typeof result === "string") result = result.trimEnd();
+				break;
+			case "camel":
+			case "camelcase":
+				if (typeof result === "string") {
+					result = result
+						.trim()
+						.replace(/[^a-zA-Z0-9]+(.)/g, (_, chr) => chr.toUpperCase())
+						.replace(/[^a-zA-Z0-9]+$/, "")
+						.replace(/^[A-Z]/, (chr) => chr.toLowerCase());
+				}
+				break;
+			case "pascal":
+			case "pascalcase":
+				if (typeof result === "string") {
+					result = result
+						.trim()
+						.replace(/[^a-zA-Z0-9]+(.)/g, (_, chr) => chr.toUpperCase())
+						.replace(/[^a-zA-Z0-9]+$/, "")
+						.replace(/^[a-z]/, (chr) => chr.toUpperCase());
+				}
+				break;
+			case "snake":
+			case "snakecase":
+				if (typeof result === "string") {
+					result = result
+						.trim()
+						.replace(/([a-z])([A-Z])/g, "$1_$2")
+						.replace(/[^a-zA-Z0-9]+/g, "_")
+						.toLowerCase()
+						.replace(/^_+|_+$/g, "");
+				}
+				break;
+			case "kebab":
+			case "kebabcase":
+				if (typeof result === "string") {
+					result = result
+						.trim()
+						.replace(/([a-z])([A-Z])/g, "$1-$2")
+						.replace(/[^a-zA-Z0-9]+/g, "-")
+						.toLowerCase()
+						.replace(/^-+|-+$/g, "");
+				}
+				break;
+			case "title":
+			case "titlecase":
+				if (typeof result === "string") {
+					result = result
+						.trim()
+						.replace(/([a-z])([A-Z])/g, "$1 $2")
+						.replace(/[^a-zA-Z0-9]+/g, " ")
+						.replace(/\b([a-z])/g, (_, chr) => chr.toUpperCase())
+						.trim();
+				}
+				break;
+			case "initials":
+				if (typeof result === "string") {
+					result = result
+						.trim()
+						.split(/\s+/)
+						.filter((word) => word.length > 0)
+						.map((word) => [...word][0].toUpperCase())
+						.join("");
+				}
+				break;
+			case "json":
+				result = JSON.stringify(result, null, 2);
+				break;
+			case "lines":
+				if (typeof result === "string") result = result.split(/\r?\n/);
+				break;
+			case "join":
+				if (Array.isArray(result)) result = result.join(", ");
+				break;
+			case "unique":
+				if (Array.isArray(result)) result = Array.from(new Set(result));
+				break;
+			case "first":
+				if (Array.isArray(result) || typeof result === "string") {
+					result = result.length > 0 ? result[0] : undefined;
+				}
+				break;
+			case "last":
+				if (Array.isArray(result) || typeof result === "string") {
+					result = result.length > 0 ? result[result.length - 1] : undefined;
+				}
+				break;
+			case "length":
+				if (Array.isArray(result) || typeof result === "string") {
+					result = result.length;
+				} else if (result != null && typeof result === "object") {
+					result = Object.keys(result).length;
+				}
+				break;
+			case "keys":
+				if (
+					result != null &&
+					typeof result === "object" &&
+					!Array.isArray(result)
+				) {
+					result = Object.keys(result);
+				}
+				break;
+			case "values":
+				if (
+					result != null &&
+					typeof result === "object" &&
+					!Array.isArray(result)
+				) {
+					result = Object.values(result);
+				}
+				break;
+			case "flat":
+				if (Array.isArray(result)) {
+					result = result.flat();
+				}
+				break;
+			case "plural":
+				if (typeof result === "number") result = result === 1 ? "" : "s";
+				break;
+			case "round":
+				if (typeof result === "number") result = Math.round(result);
+				break;
+			case "floor":
+				if (typeof result === "number") result = Math.floor(result);
+				break;
+			case "ceil":
+				if (typeof result === "number") result = Math.ceil(result);
+				break;
+			case "abs":
+				if (typeof result === "number") result = Math.abs(result);
+				break;
+			case "reverse":
+				if (Array.isArray(result)) {
+					result = [...result].reverse();
+				} else if (typeof result === "string") {
+					result = [...result].reverse().join("");
+				}
+				break;
+			case "sort":
+				if (Array.isArray(result)) {
+					result = [...result].sort();
+				}
+				break;
+			case "compact":
+				if (Array.isArray(result)) {
+					result = result.filter(
+						(item) => item !== null && item !== undefined && item !== "",
+					);
+				}
+				break;
+			case "sum":
+				if (Array.isArray(result)) {
+					result = result.reduce((acc, item) => {
+						const num = Number(item);
+						return Number.isNaN(num) ? acc : acc + num;
+					}, 0);
+				}
+				break;
+			case "avg":
+				if (Array.isArray(result)) {
+					const nums = result.map(Number).filter((n) => !Number.isNaN(n));
+					result =
+						nums.length > 0 ? nums.reduce((a, b) => a + b, 0) / nums.length : 0;
+				}
+				break;
+			case "min":
+				if (Array.isArray(result)) {
+					const nums = result.map(Number).filter((n) => !Number.isNaN(n));
+					result = nums.length > 0 ? Math.min(...nums) : undefined;
+				}
+				break;
+			case "max":
+				if (Array.isArray(result)) {
+					const nums = result.map(Number).filter((n) => !Number.isNaN(n));
+					result = nums.length > 0 ? Math.max(...nums) : undefined;
+				}
+				break;
+			case "empty":
+				result =
+					result === null ||
+					result === undefined ||
+					result === "" ||
+					(Array.isArray(result) && result.length === 0);
+				break;
+			case "notempty":
+				result = !(
+					result === null ||
+					result === undefined ||
+					result === "" ||
+					(Array.isArray(result) && result.length === 0)
+				);
+				break;
+			case "boolean":
+				result = Boolean(result);
+				break;
+		}
+	}
+	return result;
 }

--- a/packages/core/tests/index.test.ts
+++ b/packages/core/tests/index.test.ts
@@ -1,275 +1,315 @@
-import { describe, it, expect } from 'vitest';
-import { applyTransforms } from '../src/index';
+import { describe, expect, it } from "vitest";
+import { applyTransforms } from "../src/index";
 
-describe('applyTransforms', () => {
-  it('should handle upper and uppercase', () => {
-    expect(applyTransforms('hello', ['upper'])).toBe('HELLO');
-    expect(applyTransforms('hello', ['uppercase'])).toBe('HELLO');
-  });
+describe("applyTransforms", () => {
+	it("should handle upper and uppercase", () => {
+		expect(applyTransforms("hello", ["upper"])).toBe("HELLO");
+		expect(applyTransforms("hello", ["uppercase"])).toBe("HELLO");
+	});
 
-  it('should handle lower and lowercase', () => {
-    expect(applyTransforms('HELLO', ['lower'])).toBe('hello');
-    expect(applyTransforms('HELLO', ['lowercase'])).toBe('hello');
-  });
+	it("should handle lower and lowercase", () => {
+		expect(applyTransforms("HELLO", ["lower"])).toBe("hello");
+		expect(applyTransforms("HELLO", ["lowercase"])).toBe("hello");
+	});
 
-  it('should handle capitalize', () => {
-    expect(applyTransforms('hello', ['capitalize'])).toBe('Hello');
-  });
+	it("should handle capitalize", () => {
+		expect(applyTransforms("hello", ["capitalize"])).toBe("Hello");
+	});
 
-  it('should handle trim', () => {
-    expect(applyTransforms('  hello  ', ['trim'])).toBe('hello');
-  });
+	it("should handle trim", () => {
+		expect(applyTransforms("  hello  ", ["trim"])).toBe("hello");
+	});
 
-  it('should handle trimstart', () => {
-    expect(applyTransforms('  hello  ', ['trimstart'])).toBe('hello  ');
-  });
+	it("should handle trimstart", () => {
+		expect(applyTransforms("  hello  ", ["trimstart"])).toBe("hello  ");
+	});
 
-  it('should handle trimend', () => {
-    expect(applyTransforms('  hello  ', ['trimend'])).toBe('  hello');
-  });
+	it("should handle trimend", () => {
+		expect(applyTransforms("  hello  ", ["trimend"])).toBe("  hello");
+	});
 
-  it('should handle camel and camelcase', () => {
-    expect(applyTransforms('hello world', ['camel'])).toBe('helloWorld');
-    expect(applyTransforms('hello world', ['camelcase'])).toBe('helloWorld');
-    expect(applyTransforms('Hello World', ['camelcase'])).toBe('helloWorld');
-    expect(applyTransforms('hello-world', ['camelcase'])).toBe('helloWorld');
-    expect(applyTransforms('hello_world', ['camelcase'])).toBe('helloWorld');
-  });
+	it("should handle camel and camelcase", () => {
+		expect(applyTransforms("hello world", ["camel"])).toBe("helloWorld");
+		expect(applyTransforms("hello world", ["camelcase"])).toBe("helloWorld");
+		expect(applyTransforms("Hello World", ["camelcase"])).toBe("helloWorld");
+		expect(applyTransforms("hello-world", ["camelcase"])).toBe("helloWorld");
+		expect(applyTransforms("hello_world", ["camelcase"])).toBe("helloWorld");
+	});
 
-  it('should handle pascal and pascalcase', () => {
-    expect(applyTransforms('hello world', ['pascal'])).toBe('HelloWorld');
-    expect(applyTransforms('hello world', ['pascalcase'])).toBe('HelloWorld');
-    expect(applyTransforms('hello-world', ['pascalcase'])).toBe('HelloWorld');
-    expect(applyTransforms('hello_world', ['pascalcase'])).toBe('HelloWorld');
-  });
+	it("should handle pascal and pascalcase", () => {
+		expect(applyTransforms("hello world", ["pascal"])).toBe("HelloWorld");
+		expect(applyTransforms("hello world", ["pascalcase"])).toBe("HelloWorld");
+		expect(applyTransforms("hello-world", ["pascalcase"])).toBe("HelloWorld");
+		expect(applyTransforms("hello_world", ["pascalcase"])).toBe("HelloWorld");
+	});
 
-  it('should handle snake and snakecase', () => {
-    expect(applyTransforms('helloWorld', ['snake'])).toBe('hello_world');
-    expect(applyTransforms('helloWorld', ['snakecase'])).toBe('hello_world');
-    expect(applyTransforms('hello world', ['snakecase'])).toBe('hello_world');
-    expect(applyTransforms('hello-world', ['snakecase'])).toBe('hello_world');
-  });
+	it("should handle snake and snakecase", () => {
+		expect(applyTransforms("helloWorld", ["snake"])).toBe("hello_world");
+		expect(applyTransforms("helloWorld", ["snakecase"])).toBe("hello_world");
+		expect(applyTransforms("hello world", ["snakecase"])).toBe("hello_world");
+		expect(applyTransforms("hello-world", ["snakecase"])).toBe("hello_world");
+	});
 
-  it('should handle kebab and kebabcase', () => {
-    expect(applyTransforms('helloWorld', ['kebab'])).toBe('hello-world');
-    expect(applyTransforms('helloWorld', ['kebabcase'])).toBe('hello-world');
-    expect(applyTransforms('hello world', ['kebabcase'])).toBe('hello-world');
-    expect(applyTransforms('hello_world', ['kebabcase'])).toBe('hello-world');
-  });
+	it("should handle kebab and kebabcase", () => {
+		expect(applyTransforms("helloWorld", ["kebab"])).toBe("hello-world");
+		expect(applyTransforms("helloWorld", ["kebabcase"])).toBe("hello-world");
+		expect(applyTransforms("hello world", ["kebabcase"])).toBe("hello-world");
+		expect(applyTransforms("hello_world", ["kebabcase"])).toBe("hello-world");
+	});
 
-  it('should handle title and titlecase', () => {
-    expect(applyTransforms('hello world', ['title'])).toBe('Hello World');
-    expect(applyTransforms('hello world', ['titlecase'])).toBe('Hello World');
-    expect(applyTransforms('hello-world', ['titlecase'])).toBe('Hello World');
-    expect(applyTransforms('hello_world', ['titlecase'])).toBe('Hello World');
-    expect(applyTransforms('helloWorld', ['titlecase'])).toBe('Hello World');
-    expect(applyTransforms('  hello   world  ', ['titlecase'])).toBe('Hello World');
-  });
+	it("should handle title and titlecase", () => {
+		expect(applyTransforms("hello world", ["title"])).toBe("Hello World");
+		expect(applyTransforms("hello world", ["titlecase"])).toBe("Hello World");
+		expect(applyTransforms("hello-world", ["titlecase"])).toBe("Hello World");
+		expect(applyTransforms("hello_world", ["titlecase"])).toBe("Hello World");
+		expect(applyTransforms("helloWorld", ["titlecase"])).toBe("Hello World");
+		expect(applyTransforms("  hello   world  ", ["titlecase"])).toBe(
+			"Hello World",
+		);
+	});
 
-  it('should handle chained transformations', () => {
-    expect(applyTransforms('  hello world  ', ['trim', 'camelcase', 'capitalize'])).toBe('HelloWorld');
-  });
+	it("should handle initials transformation", () => {
+		expect(applyTransforms("hello world", ["initials"])).toBe("HW");
+		expect(applyTransforms("Spark Agent", ["initials"])).toBe("SA");
+		expect(applyTransforms("  multiple   spaces  ", ["initials"])).toBe("MS");
+		expect(applyTransforms("unicode 💩 emoji", ["initials"])).toBe("U💩E");
+		expect(applyTransforms("single", ["initials"])).toBe("S");
+		expect(applyTransforms("", ["initials"])).toBe("");
+		expect(applyTransforms(123, ["initials"])).toBe(123);
+	});
 
-  it('should return original value for non-strings when using string-only transforms', () => {
-    expect(applyTransforms(123, ['upper'])).toBe(123);
-    expect(applyTransforms(null, ['upper'])).toBe(null);
-  });
+	it("should handle chained transformations", () => {
+		expect(
+			applyTransforms("  hello world  ", ["trim", "camelcase", "capitalize"]),
+		).toBe("HelloWorld");
+	});
 
-  it('should handle json transformation', () => {
-    const obj = { a: 1, b: 'hello' };
-    expect(applyTransforms(obj, ['json'])).toBe(JSON.stringify(obj, null, 2));
-    expect(applyTransforms([1, 2, 3], ['json'])).toBe(JSON.stringify([1, 2, 3], null, 2));
-    expect(applyTransforms('hello', ['json'])).toBe('"hello"');
-  });
+	it("should return original value for non-strings when using string-only transforms", () => {
+		expect(applyTransforms(123, ["upper"])).toBe(123);
+		expect(applyTransforms(null, ["upper"])).toBe(null);
+	});
 
-  it('should handle lines transformation', () => {
-    expect(applyTransforms("line1\nline2\r\nline3", ['lines'])).toEqual(['line1', 'line2', 'line3']);
-    expect(applyTransforms("single line", ['lines'])).toEqual(['single line']);
-    expect(applyTransforms(123, ['lines'])).toBe(123);
-  });
+	it("should handle json transformation", () => {
+		const obj = { a: 1, b: "hello" };
+		expect(applyTransforms(obj, ["json"])).toBe(JSON.stringify(obj, null, 2));
+		expect(applyTransforms([1, 2, 3], ["json"])).toBe(
+			JSON.stringify([1, 2, 3], null, 2),
+		);
+		expect(applyTransforms("hello", ["json"])).toBe('"hello"');
+	});
 
-  it('should handle chained transformations with json', () => {
-    const obj = { name: 'spark' };
-    // json -> uppercase (no effect as json returns string, but uppercase works on it)
-    const jsonStr = JSON.stringify(obj, null, 2);
-    expect(applyTransforms(obj, ['json', 'uppercase'])).toBe(jsonStr.toUpperCase());
-  });
+	it("should handle lines transformation", () => {
+		expect(applyTransforms("line1\nline2\r\nline3", ["lines"])).toEqual([
+			"line1",
+			"line2",
+			"line3",
+		]);
+		expect(applyTransforms("single line", ["lines"])).toEqual(["single line"]);
+		expect(applyTransforms(123, ["lines"])).toBe(123);
+	});
 
-  it('should handle join transformation', () => {
-    expect(applyTransforms(['a', 'b', 'c'], ['join'])).toBe('a, b, c');
-    expect(applyTransforms([], ['join'])).toBe('');
-    expect(applyTransforms('not an array', ['join'])).toBe('not an array');
-  });
+	it("should handle chained transformations with json", () => {
+		const obj = { name: "spark" };
+		// json -> uppercase (no effect as json returns string, but uppercase works on it)
+		const jsonStr = JSON.stringify(obj, null, 2);
+		expect(applyTransforms(obj, ["json", "uppercase"])).toBe(
+			jsonStr.toUpperCase(),
+		);
+	});
 
-  it('should handle unique transformation', () => {
-    expect(applyTransforms(['a', 'b', 'a', 'c', 'b'], ['unique'])).toEqual(['a', 'b', 'c']);
-    expect(applyTransforms([1, 2, 1, 3, 2], ['unique'])).toEqual([1, 2, 3]);
-    expect(applyTransforms([], ['unique'])).toEqual([]);
-    expect(applyTransforms('not an array', ['unique'])).toBe('not an array');
-  });
+	it("should handle join transformation", () => {
+		expect(applyTransforms(["a", "b", "c"], ["join"])).toBe("a, b, c");
+		expect(applyTransforms([], ["join"])).toBe("");
+		expect(applyTransforms("not an array", ["join"])).toBe("not an array");
+	});
 
-  it('should handle first transformation', () => {
-    expect(applyTransforms(['a', 'b', 'c'], ['first'])).toBe('a');
-    expect(applyTransforms('hello', ['first'])).toBe('h');
-    expect(applyTransforms([], ['first'])).toBeUndefined();
-    expect(applyTransforms('', ['first'])).toBeUndefined();
-  });
+	it("should handle unique transformation", () => {
+		expect(applyTransforms(["a", "b", "a", "c", "b"], ["unique"])).toEqual([
+			"a",
+			"b",
+			"c",
+		]);
+		expect(applyTransforms([1, 2, 1, 3, 2], ["unique"])).toEqual([1, 2, 3]);
+		expect(applyTransforms([], ["unique"])).toEqual([]);
+		expect(applyTransforms("not an array", ["unique"])).toBe("not an array");
+	});
 
-  it('should handle last transformation', () => {
-    expect(applyTransforms(['a', 'b', 'c'], ['last'])).toBe('c');
-    expect(applyTransforms('hello', ['last'])).toBe('o');
-    expect(applyTransforms([], ['last'])).toBeUndefined();
-    expect(applyTransforms('', ['last'])).toBeUndefined();
-  });
+	it("should handle first transformation", () => {
+		expect(applyTransforms(["a", "b", "c"], ["first"])).toBe("a");
+		expect(applyTransforms("hello", ["first"])).toBe("h");
+		expect(applyTransforms([], ["first"])).toBeUndefined();
+		expect(applyTransforms("", ["first"])).toBeUndefined();
+	});
 
-  it('should handle length transformation', () => {
-    expect(applyTransforms(['a', 'b', 'c'], ['length'])).toBe(3);
-    expect(applyTransforms('hello', ['length'])).toBe(5);
-    expect(applyTransforms([], ['length'])).toBe(0);
-    expect(applyTransforms('', ['length'])).toBe(0);
-    expect(applyTransforms({ a: 1, b: 2 }, ['length'])).toBe(2);
-    expect(applyTransforms({}, ['length'])).toBe(0);
-  });
+	it("should handle last transformation", () => {
+		expect(applyTransforms(["a", "b", "c"], ["last"])).toBe("c");
+		expect(applyTransforms("hello", ["last"])).toBe("o");
+		expect(applyTransforms([], ["last"])).toBeUndefined();
+		expect(applyTransforms("", ["last"])).toBeUndefined();
+	});
 
-  it('should handle keys transformation', () => {
-    expect(applyTransforms({ a: 1, b: 2 }, ['keys'])).toEqual(['a', 'b']);
-    expect(applyTransforms({}, ['keys'])).toEqual([]);
-    expect(applyTransforms(['a', 'b'], ['keys'])).toEqual(['a', 'b']); // should skip arrays
-    expect(applyTransforms('not an object', ['keys'])).toBe('not an object');
-  });
+	it("should handle length transformation", () => {
+		expect(applyTransforms(["a", "b", "c"], ["length"])).toBe(3);
+		expect(applyTransforms("hello", ["length"])).toBe(5);
+		expect(applyTransforms([], ["length"])).toBe(0);
+		expect(applyTransforms("", ["length"])).toBe(0);
+		expect(applyTransforms({ a: 1, b: 2 }, ["length"])).toBe(2);
+		expect(applyTransforms({}, ["length"])).toBe(0);
+	});
 
-  it('should handle values transformation', () => {
-    expect(applyTransforms({ a: 1, b: 2 }, ['values'])).toEqual([1, 2]);
-    expect(applyTransforms({}, ['values'])).toEqual([]);
-    expect(applyTransforms(['a', 'b'], ['values'])).toEqual(['a', 'b']); // should skip arrays
-    expect(applyTransforms('not an object', ['values'])).toBe('not an object');
-  });
+	it("should handle keys transformation", () => {
+		expect(applyTransforms({ a: 1, b: 2 }, ["keys"])).toEqual(["a", "b"]);
+		expect(applyTransforms({}, ["keys"])).toEqual([]);
+		expect(applyTransforms(["a", "b"], ["keys"])).toEqual(["a", "b"]); // should skip arrays
+		expect(applyTransforms("not an object", ["keys"])).toBe("not an object");
+	});
 
-  it('should handle flat transformation', () => {
-    expect(applyTransforms([[1, 2], [3, 4]], ['flat'])).toEqual([1, 2, 3, 4]);
-    expect(applyTransforms([1, [2, [3]]], ['flat'])).toEqual([1, 2, [3]]);
-    expect(applyTransforms([], ['flat'])).toEqual([]);
-    expect(applyTransforms('not an array', ['flat'])).toBe('not an array');
-  });
+	it("should handle values transformation", () => {
+		expect(applyTransforms({ a: 1, b: 2 }, ["values"])).toEqual([1, 2]);
+		expect(applyTransforms({}, ["values"])).toEqual([]);
+		expect(applyTransforms(["a", "b"], ["values"])).toEqual(["a", "b"]); // should skip arrays
+		expect(applyTransforms("not an object", ["values"])).toBe("not an object");
+	});
 
-  it('should handle plural transformation', () => {
-    expect(applyTransforms(0, ['plural'])).toBe('s');
-    expect(applyTransforms(1, ['plural'])).toBe('');
-    expect(applyTransforms(2, ['plural'])).toBe('s');
-    expect(applyTransforms(1.5, ['plural'])).toBe('s');
-    expect(applyTransforms('not a number', ['plural'])).toBe('not a number');
-  });
+	it("should handle flat transformation", () => {
+		expect(
+			applyTransforms(
+				[
+					[1, 2],
+					[3, 4],
+				],
+				["flat"],
+			),
+		).toEqual([1, 2, 3, 4]);
+		expect(applyTransforms([1, [2, [3]]], ["flat"])).toEqual([1, 2, [3]]);
+		expect(applyTransforms([], ["flat"])).toEqual([]);
+		expect(applyTransforms("not an array", ["flat"])).toBe("not an array");
+	});
 
-  it('should handle round transformation', () => {
-    expect(applyTransforms(1.4, ['round'])).toBe(1);
-    expect(applyTransforms(1.5, ['round'])).toBe(2);
-    expect(applyTransforms(1.6, ['round'])).toBe(2);
-    expect(applyTransforms(-1.5, ['round'])).toBe(-1); // Math.round(-1.5) is -1
-    expect(applyTransforms('not a number', ['round'])).toBe('not a number');
-  });
+	it("should handle plural transformation", () => {
+		expect(applyTransforms(0, ["plural"])).toBe("s");
+		expect(applyTransforms(1, ["plural"])).toBe("");
+		expect(applyTransforms(2, ["plural"])).toBe("s");
+		expect(applyTransforms(1.5, ["plural"])).toBe("s");
+		expect(applyTransforms("not a number", ["plural"])).toBe("not a number");
+	});
 
-  it('should handle floor transformation', () => {
-    expect(applyTransforms(1.9, ['floor'])).toBe(1);
-    expect(applyTransforms(-1.1, ['floor'])).toBe(-2);
-    expect(applyTransforms('not a number', ['floor'])).toBe('not a number');
-  });
+	it("should handle round transformation", () => {
+		expect(applyTransforms(1.4, ["round"])).toBe(1);
+		expect(applyTransforms(1.5, ["round"])).toBe(2);
+		expect(applyTransforms(1.6, ["round"])).toBe(2);
+		expect(applyTransforms(-1.5, ["round"])).toBe(-1); // Math.round(-1.5) is -1
+		expect(applyTransforms("not a number", ["round"])).toBe("not a number");
+	});
 
-  it('should handle ceil transformation', () => {
-    expect(applyTransforms(1.1, ['ceil'])).toBe(2);
-    expect(applyTransforms(-1.9, ['ceil'])).toBe(-1);
-    expect(applyTransforms('not a number', ['ceil'])).toBe('not a number');
-  });
+	it("should handle floor transformation", () => {
+		expect(applyTransforms(1.9, ["floor"])).toBe(1);
+		expect(applyTransforms(-1.1, ["floor"])).toBe(-2);
+		expect(applyTransforms("not a number", ["floor"])).toBe("not a number");
+	});
 
-  it('should handle abs transformation', () => {
-    expect(applyTransforms(-5, ['abs'])).toBe(5);
-    expect(applyTransforms(5, ['abs'])).toBe(5);
-    expect(applyTransforms('not a number', ['abs'])).toBe('not a number');
-  });
+	it("should handle ceil transformation", () => {
+		expect(applyTransforms(1.1, ["ceil"])).toBe(2);
+		expect(applyTransforms(-1.9, ["ceil"])).toBe(-1);
+		expect(applyTransforms("not a number", ["ceil"])).toBe("not a number");
+	});
 
-  it('should handle reverse transformation', () => {
-    expect(applyTransforms(['a', 'b', 'c'], ['reverse'])).toEqual(['c', 'b', 'a']);
-    expect(applyTransforms('hello', ['reverse'])).toBe('olleh');
-    expect(applyTransforms([], ['reverse'])).toEqual([]);
-    expect(applyTransforms('', ['reverse'])).toBe('');
-    expect(applyTransforms(123, ['reverse'])).toBe(123);
-  });
+	it("should handle abs transformation", () => {
+		expect(applyTransforms(-5, ["abs"])).toBe(5);
+		expect(applyTransforms(5, ["abs"])).toBe(5);
+		expect(applyTransforms("not a number", ["abs"])).toBe("not a number");
+	});
 
-  it('should handle sort transformation', () => {
-    expect(applyTransforms(['c', 'a', 'b'], ['sort'])).toEqual(['a', 'b', 'c']);
-    expect(applyTransforms([3, 1, 2], ['sort'])).toEqual([1, 2, 3]);
-    expect(applyTransforms([], ['sort'])).toEqual([]);
-    expect(applyTransforms('not an array', ['sort'])).toBe('not an array');
-  });
+	it("should handle reverse transformation", () => {
+		expect(applyTransforms(["a", "b", "c"], ["reverse"])).toEqual([
+			"c",
+			"b",
+			"a",
+		]);
+		expect(applyTransforms("hello", ["reverse"])).toBe("olleh");
+		expect(applyTransforms([], ["reverse"])).toEqual([]);
+		expect(applyTransforms("", ["reverse"])).toBe("");
+		expect(applyTransforms(123, ["reverse"])).toBe(123);
+	});
 
-  it('should handle compact transformation', () => {
-    expect(applyTransforms(['a', '', null, 'b', undefined, 'c'], ['compact'])).toEqual(['a', 'b', 'c']);
-    expect(applyTransforms([], ['compact'])).toEqual([]);
-    expect(applyTransforms('not an array', ['compact'])).toBe('not an array');
-  });
+	it("should handle sort transformation", () => {
+		expect(applyTransforms(["c", "a", "b"], ["sort"])).toEqual(["a", "b", "c"]);
+		expect(applyTransforms([3, 1, 2], ["sort"])).toEqual([1, 2, 3]);
+		expect(applyTransforms([], ["sort"])).toEqual([]);
+		expect(applyTransforms("not an array", ["sort"])).toBe("not an array");
+	});
 
-  it('should handle sum transformation', () => {
-    expect(applyTransforms([1, 2, 3], ['sum'])).toBe(6);
-    expect(applyTransforms(['1', '2', '3'], ['sum'])).toBe(6);
-    expect(applyTransforms([1, 'invalid', 2], ['sum'])).toBe(3);
-    expect(applyTransforms([], ['sum'])).toBe(0);
-    expect(applyTransforms('not an array', ['sum'])).toBe('not an array');
-  });
+	it("should handle compact transformation", () => {
+		expect(
+			applyTransforms(["a", "", null, "b", undefined, "c"], ["compact"]),
+		).toEqual(["a", "b", "c"]);
+		expect(applyTransforms([], ["compact"])).toEqual([]);
+		expect(applyTransforms("not an array", ["compact"])).toBe("not an array");
+	});
 
-  it('should handle avg transformation', () => {
-    expect(applyTransforms([2, 4, 6], ['avg'])).toBe(4);
-    expect(applyTransforms(['2', '4', '6'], ['avg'])).toBe(4);
-    expect(applyTransforms([2, 'invalid', 4], ['avg'])).toBe(3);
-    expect(applyTransforms([], ['avg'])).toBe(0);
-    expect(applyTransforms('not an array', ['avg'])).toBe('not an array');
-  });
+	it("should handle sum transformation", () => {
+		expect(applyTransforms([1, 2, 3], ["sum"])).toBe(6);
+		expect(applyTransforms(["1", "2", "3"], ["sum"])).toBe(6);
+		expect(applyTransforms([1, "invalid", 2], ["sum"])).toBe(3);
+		expect(applyTransforms([], ["sum"])).toBe(0);
+		expect(applyTransforms("not an array", ["sum"])).toBe("not an array");
+	});
 
-  it('should handle min transformation', () => {
-    expect(applyTransforms([2, 4, 1, 6], ['min'])).toBe(1);
-    expect(applyTransforms(['2', '4', '1', '6'], ['min'])).toBe(1);
-    expect(applyTransforms([2, 'invalid', 1], ['min'])).toBe(1);
-    expect(applyTransforms([], ['min'])).toBeUndefined();
-    expect(applyTransforms(['invalid'], ['min'])).toBeUndefined();
-    expect(applyTransforms('not an array', ['min'])).toBe('not an array');
-  });
+	it("should handle avg transformation", () => {
+		expect(applyTransforms([2, 4, 6], ["avg"])).toBe(4);
+		expect(applyTransforms(["2", "4", "6"], ["avg"])).toBe(4);
+		expect(applyTransforms([2, "invalid", 4], ["avg"])).toBe(3);
+		expect(applyTransforms([], ["avg"])).toBe(0);
+		expect(applyTransforms("not an array", ["avg"])).toBe("not an array");
+	});
 
-  it('should handle max transformation', () => {
-    expect(applyTransforms([2, 4, 1, 6], ['max'])).toBe(6);
-    expect(applyTransforms(['2', '4', '1', '6'], ['max'])).toBe(6);
-    expect(applyTransforms([2, 'invalid', 6], ['max'])).toBe(6);
-    expect(applyTransforms([], ['max'])).toBeUndefined();
-    expect(applyTransforms(['invalid'], ['max'])).toBeUndefined();
-    expect(applyTransforms('not an array', ['max'])).toBe('not an array');
-  });
+	it("should handle min transformation", () => {
+		expect(applyTransforms([2, 4, 1, 6], ["min"])).toBe(1);
+		expect(applyTransforms(["2", "4", "1", "6"], ["min"])).toBe(1);
+		expect(applyTransforms([2, "invalid", 1], ["min"])).toBe(1);
+		expect(applyTransforms([], ["min"])).toBeUndefined();
+		expect(applyTransforms(["invalid"], ["min"])).toBeUndefined();
+		expect(applyTransforms("not an array", ["min"])).toBe("not an array");
+	});
 
-  it('should handle empty transformation', () => {
-    expect(applyTransforms(null, ['empty'])).toBe(true);
-    expect(applyTransforms(undefined, ['empty'])).toBe(true);
-    expect(applyTransforms('', ['empty'])).toBe(true);
-    expect(applyTransforms([], ['empty'])).toBe(true);
-    expect(applyTransforms('hello', ['empty'])).toBe(false);
-    expect(applyTransforms(['a'], ['empty'])).toBe(false);
-    expect(applyTransforms(0, ['empty'])).toBe(false);
-    expect(applyTransforms(false, ['empty'])).toBe(false);
-  });
+	it("should handle max transformation", () => {
+		expect(applyTransforms([2, 4, 1, 6], ["max"])).toBe(6);
+		expect(applyTransforms(["2", "4", "1", "6"], ["max"])).toBe(6);
+		expect(applyTransforms([2, "invalid", 6], ["max"])).toBe(6);
+		expect(applyTransforms([], ["max"])).toBeUndefined();
+		expect(applyTransforms(["invalid"], ["max"])).toBeUndefined();
+		expect(applyTransforms("not an array", ["max"])).toBe("not an array");
+	});
 
-  it('should handle notempty transformation', () => {
-    expect(applyTransforms(null, ['notempty'])).toBe(false);
-    expect(applyTransforms(undefined, ['notempty'])).toBe(false);
-    expect(applyTransforms('', ['notempty'])).toBe(false);
-    expect(applyTransforms([], ['notempty'])).toBe(false);
-    expect(applyTransforms('hello', ['notempty'])).toBe(true);
-    expect(applyTransforms(['a'], ['notempty'])).toBe(true);
-    expect(applyTransforms(0, ['notempty'])).toBe(true);
-    expect(applyTransforms(false, ['notempty'])).toBe(true);
-  });
+	it("should handle empty transformation", () => {
+		expect(applyTransforms(null, ["empty"])).toBe(true);
+		expect(applyTransforms(undefined, ["empty"])).toBe(true);
+		expect(applyTransforms("", ["empty"])).toBe(true);
+		expect(applyTransforms([], ["empty"])).toBe(true);
+		expect(applyTransforms("hello", ["empty"])).toBe(false);
+		expect(applyTransforms(["a"], ["empty"])).toBe(false);
+		expect(applyTransforms(0, ["empty"])).toBe(false);
+		expect(applyTransforms(false, ["empty"])).toBe(false);
+	});
 
-  it('should handle boolean transformation', () => {
-    expect(applyTransforms(1, ['boolean'])).toBe(true);
-    expect(applyTransforms(0, ['boolean'])).toBe(false);
-    expect(applyTransforms('hello', ['boolean'])).toBe(true);
-    expect(applyTransforms('', ['boolean'])).toBe(false);
-    expect(applyTransforms(null, ['boolean'])).toBe(false);
-    expect(applyTransforms(undefined, ['boolean'])).toBe(false);
-    expect(applyTransforms([], ['boolean'])).toBe(true); // empty array is truthy in JS
-  });
+	it("should handle notempty transformation", () => {
+		expect(applyTransforms(null, ["notempty"])).toBe(false);
+		expect(applyTransforms(undefined, ["notempty"])).toBe(false);
+		expect(applyTransforms("", ["notempty"])).toBe(false);
+		expect(applyTransforms([], ["notempty"])).toBe(false);
+		expect(applyTransforms("hello", ["notempty"])).toBe(true);
+		expect(applyTransforms(["a"], ["notempty"])).toBe(true);
+		expect(applyTransforms(0, ["notempty"])).toBe(true);
+		expect(applyTransforms(false, ["notempty"])).toBe(true);
+	});
+
+	it("should handle boolean transformation", () => {
+		expect(applyTransforms(1, ["boolean"])).toBe(true);
+		expect(applyTransforms(0, ["boolean"])).toBe(false);
+		expect(applyTransforms("hello", ["boolean"])).toBe(true);
+		expect(applyTransforms("", ["boolean"])).toBe(false);
+		expect(applyTransforms(null, ["boolean"])).toBe(false);
+		expect(applyTransforms(undefined, ["boolean"])).toBe(false);
+		expect(applyTransforms([], ["boolean"])).toBe(true); // empty array is truthy in JS
+	});
 });


### PR DESCRIPTION
💡 **What:** Added a new `initials` transformation to the `@interpolator/core` library.
🎯 **Why:** To provide a simple way for users to generate initials from strings (e.g., for avatars or shorthand labels) directly within templates.
📦 **What it adds:** A new `initials` pipe transformation that trims the input, splits by whitespace, and returns the first character of each word in uppercase.
🚀 **How to use:** `{{ user.name | initials }}` (e.g., "John Doe" -> "JD").
♻️ **Deps Free:** Zero new dependencies; uses native JavaScript APIs.
🎨 **Harmony:** Follows the existing `applyTransforms` pattern and uses Unicode-safe character access to ensure robustness across all data types.

---
*PR created automatically by Jules for task [3900414217719555889](https://jules.google.com/task/3900414217719555889) started by @galiprandi*