### PR TITLE
⚡ Spark: Range transform for dynamic row expansion

### DIFF
--- a/.axioma/spark.md
+++ b/.axioma/spark.md
@@ -75,3 +75,7 @@
 ## 2026-07-15 - [Object and Array Manipulation Transforms]
 **Learning:** Providing basic object introspection (`keys`, `values`) and array manipulation (`flat`) transforms allows users to handle more complex data structures directly in templates. Updating `length` to support objects makes the API more consistent across different data types.
 **Pattern:** Extend core utilities to support both arrays and objects where it makes sense (like `length`), and provide specific transforms for type-specific operations that follow standard JavaScript behavior.
+
+## 2026-07-25 - [Sequence Generation via Range Transform]
+**Learning:** Providing a way to generate sequences directly from a number (via `range`) allows users to create dynamic row counts or lists without needing to pre-calculate arrays in their data source. This is particularly useful for things like "Top N" lists or fixed-size forms.
+**Pattern:** Use simple, numeric-to-collection transforms to bridge the gap between scalar data and structural document requirements (like row expansion).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ After interpolation with the data above, the result would be:
 - **Type Preservation**: If the cell contains *only* the `{{key}}` marker, the resulting cell will have the same type as the data (e.g., Number, Date, Boolean).
 - Supports nested paths: `{{user.profile.email}}`.
 - **Default values**: `{{path || fallback}}`. Fallback can be a literal string or another path.
-- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`/`uppercase`, `lower`/`lowercase`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `join`, `unique`, `first`, `last`, `length`, `plural`, `round`, `floor`, `ceil`, `abs`, `reverse`, `sort`, `compact`, `sum`, `avg`, `min`, `max`, `year`, `month`, `day`, `hour`, `minute`, `second`, `weekday`, `empty`, `notempty`, `boolean`, `number`, `string`. You can chain them: `{{title | trim | capitalize}}`.
+- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`/`uppercase`, `lower`/`lowercase`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `join`, `unique`, `first`, `last`, `length`, `plural`, `round`, `floor`, `ceil`, `abs`, `range`, `reverse`, `sort`, `compact`, `sum`, `avg`, `min`, `max`, `year`, `month`, `day`, `hour`, `minute`, `second`, `weekday`, `empty`, `notempty`, `boolean`, `number`, `string`. You can chain them: `{{title | trim | capitalize}}`.
 - If the key is missing and no default is provided, the marker remains in the cell as-is.
 - If the value is `null` or `undefined` and no default is provided, the cell becomes empty (`""`).
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Used for static values that appear once in your document (e.g., a customer name,
 - **Nested Paths**: Supports dot notation like `{{user.profile.name}}`.
 - **Missing Data**: If a key is missing, the marker `{{key}}` stays in the cell for easier debugging.
 - **Null Values**: If a value is `null` or `undefined`, the cell is cleared.
-- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`, `lower`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `join`, `unique`, `first`, `last`, `length`, `plural`, `round`, `floor`, `ceil`, `abs`, `reverse`, `sort`, `compact`, `sum`, `avg`, `min`, `max`, `year`, `month`, `day`, `hour`, `minute`, `second`, `weekday`, `empty`, `notempty`, `boolean`, `number`, `string`. You can chain them: `{{title | trim | capitalize}}`.
+- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`, `lower`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `join`, `unique`, `first`, `last`, `length`, `plural`, `round`, `floor`, `ceil`, `abs`, `range`, `reverse`, `sort`, `compact`, `sum`, `avg`, `min`, `max`, `year`, `month`, `day`, `hour`, `minute`, `second`, `weekday`, `empty`, `notempty`, `boolean`, `number`, `string`. You can chain them: `{{title | trim | capitalize}}`.
 
 #### Array-Based Row Expansion: `[[array.key]]`
 Used to repeat an entire row for every item in an array.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -201,6 +201,12 @@ export function applyTransforms(value: any, transforms: string[]): any {
 			case "abs":
 				if (typeof result === "number") result = Math.abs(result);
 				break;
+			case "range":
+				if (typeof result === "number") {
+					const n = Math.floor(result);
+					result = n > 0 ? Array.from({ length: n }, (_, i) => i + 1) : [];
+				}
+				break;
 			case "reverse":
 				if (Array.isArray(result)) {
 					result = [...result].reverse();

--- a/packages/core/tests/index.test.ts
+++ b/packages/core/tests/index.test.ts
@@ -220,6 +220,15 @@ describe("applyTransforms", () => {
 		expect(applyTransforms("not a number", ["abs"])).toBe("not a number");
 	});
 
+	it("should handle range transformation", () => {
+		expect(applyTransforms(3, ["range"])).toEqual([1, 2, 3]);
+		expect(applyTransforms(5.7, ["range"])).toEqual([1, 2, 3, 4, 5]);
+		expect(applyTransforms(1, ["range"])).toEqual([1]);
+		expect(applyTransforms(0, ["range"])).toEqual([]);
+		expect(applyTransforms(-5, ["range"])).toEqual([]);
+		expect(applyTransforms("not a number", ["range"])).toBe("not a number");
+	});
+
 	it("should handle reverse transformation", () => {
 		expect(applyTransforms(["a", "b", "c"], ["reverse"])).toEqual([
 			"c",

--- a/packages/xlsx/tests/functional.test.ts
+++ b/packages/xlsx/tests/functional.test.ts
@@ -901,5 +901,23 @@ describe('interpolateXlsx - functional', () => {
       expect(ws.getCell('A1').value).toBe('SPARK');
       expect(ws.getCell('A2').value).toBe('AGENT');
     });
+
+    it('should support range transform for row expansion', async () => {
+      const template = await buildTemplateBuffer((wb) => {
+        const ws = wb.addWorksheet('Sheet1');
+        ws.getCell('A1').value = '[[count | range]]';
+      });
+
+      const data = { count: 3 };
+      const result = await interpolateXlsx({ template, data });
+      const wb = new Workbook();
+      await wb.xlsx.load(result as any);
+      const ws = wb.getWorksheet('Sheet1');
+
+      expect(ws?.getCell('A1').value).toBe(1);
+      expect(ws?.getCell('A2').value).toBe(2);
+      expect(ws?.getCell('A3').value).toBe(3);
+      expect(ws?.getRow(4).getCell(1).value).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
💡 **What:** Added a new `range` transform to `@interpolator/core`.
🎯 **Why:** Allows users to repeat Excel rows a specific number of times without needing to provide an array in the data source.
📦 **What it adds:** `range` transform which converts a number `N` into `[1, ..., floor(N)]`.
🚀 **How to use:** `[[ count | range ]]` in an Excel template row, where `count` is a number in your data.
♻️ **Deps Free:** Uses only built-in JavaScript APIs.
🎨 **Harmony:** Follows existing transform patterns and integrates seamlessly with the XLSX row expansion logic.

---
*PR created automatically by Jules for task [8745673305195964072](https://jules.google.com/task/8745673305195964072) started by @galiprandi*