### PR TITLE
⚡ Spark: entries transform

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ After interpolation with the data above, the result would be:
 - **Type Preservation**: If the cell contains *only* the `{{key}}` marker, the resulting cell will have the same type as the data (e.g., Number, Date, Boolean).
 - Supports nested paths: `{{user.profile.email}}`.
 - **Default values**: `{{path || fallback}}`. Fallback can be a literal string or another path.
-- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`/`uppercase`, `lower`/`lowercase`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `join`, `unique`, `first`, `last`, `length`, `plural`, `round`, `floor`, `ceil`, `abs`, `range`, `reverse`, `sort`, `compact`, `sum`, `avg`, `min`, `max`, `year`, `month`, `day`, `hour`, `minute`, `second`, `weekday`, `empty`, `notempty`, `boolean`, `number`, `string`. You can chain them: `{{title | trim | capitalize}}`.
+- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`/`uppercase`, `lower`/`lowercase`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `join`, `unique`, `first`, `last`, `length`, `entries`, `plural`, `round`, `floor`, `ceil`, `abs`, `range`, `reverse`, `sort`, `compact`, `sum`, `avg`, `min`, `max`, `year`, `month`, `day`, `hour`, `minute`, `second`, `weekday`, `empty`, `notempty`, `boolean`, `number`, `string`. You can chain them: `{{title | trim | capitalize}}`.
 - If the key is missing and no default is provided, the marker remains in the cell as-is.
 - If the value is `null` or `undefined` and no default is provided, the cell becomes empty (`""`).
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Used for static values that appear once in your document (e.g., a customer name,
 - **Nested Paths**: Supports dot notation like `{{user.profile.name}}`.
 - **Missing Data**: If a key is missing, the marker `{{key}}` stays in the cell for easier debugging.
 - **Null Values**: If a value is `null` or `undefined`, the cell is cleared.
-- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`, `lower`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `join`, `unique`, `first`, `last`, `length`, `plural`, `round`, `floor`, `ceil`, `abs`, `range`, `reverse`, `sort`, `compact`, `sum`, `avg`, `min`, `max`, `year`, `month`, `day`, `hour`, `minute`, `second`, `weekday`, `empty`, `notempty`, `boolean`, `number`, `string`. You can chain them: `{{title | trim | capitalize}}`.
+- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`, `lower`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `join`, `unique`, `first`, `last`, `length`, `entries`, `plural`, `round`, `floor`, `ceil`, `abs`, `range`, `reverse`, `sort`, `compact`, `sum`, `avg`, `min`, `max`, `year`, `month`, `day`, `hour`, `minute`, `second`, `weekday`, `empty`, `notempty`, `boolean`, `number`, `string`. You can chain them: `{{title | trim | capitalize}}`.
 
 #### Array-Based Row Expansion: `[[array.key]]`
 Used to repeat an entire row for every item in an array.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -268,6 +268,18 @@ export function applyTransforms(value: any, transforms: string[]): any {
 					(Array.isArray(result) && result.length === 0)
 				);
 				break;
+			case "entries":
+				if (
+					result != null &&
+					typeof result === "object" &&
+					!Array.isArray(result)
+				) {
+					result = Object.entries(result).map(([key, value]) => ({
+						key,
+						value,
+					}));
+				}
+				break;
 			case "boolean":
 				result = Boolean(result);
 				break;

--- a/packages/core/tests/index.test.ts
+++ b/packages/core/tests/index.test.ts
@@ -312,6 +312,17 @@ describe("applyTransforms", () => {
 		expect(applyTransforms(false, ["notempty"])).toBe(true);
 	});
 
+	it("should handle entries transformation", () => {
+		const obj = { a: 1, b: "hello" };
+		expect(applyTransforms(obj, ["entries"])).toEqual([
+			{ key: "a", value: 1 },
+			{ key: "b", value: "hello" },
+		]);
+		expect(applyTransforms({}, ["entries"])).toEqual([]);
+		expect(applyTransforms(["a", "b"], ["entries"])).toEqual(["a", "b"]); // skip arrays
+		expect(applyTransforms("not an object", ["entries"])).toBe("not an object");
+	});
+
 	it("should handle boolean transformation", () => {
 		expect(applyTransforms(1, ["boolean"])).toBe(true);
 		expect(applyTransforms(0, ["boolean"])).toBe(false);


### PR DESCRIPTION
💡 **What:** Added the `entries` transformation to the core interpolation engine.
🎯 **Why:** Users often need to iterate over object properties when they don't know the keys beforehand or want to display metadata as a list.
📦 **What it adds:** A new `| entries` transform that converts `{ a: 1, b: 2 }` into `[{ key: 'a', value: 1 }, { key: 'b', value: 2 }]`.
🚀 **How to use:** `{{ myObject | entries | join }}` or in row expansion `[[ myObject | entries . key ]]`.
♻️ **Deps Free:** Uses only built-in `Object.entries`.
🎨 **Harmony:** Follows the existing transform pattern and integrates seamlessly with both `{{}}` and `[[ ]]` markers.

---
*PR created automatically by Jules for task [9959322402222725785](https://jules.google.com/task/9959322402222725785) started by @galiprandi*