### PR TITLE
⚡ Spark: add entries transform and document missing transforms

### DIFF
--- a/.axioma/spark.md
+++ b/.axioma/spark.md
@@ -79,3 +79,7 @@
 ## 2026-07-25 - [Sequence Generation via Range Transform]
 **Learning:** Providing a way to generate sequences directly from a number (via `range`) allows users to create dynamic row counts or lists without needing to pre-calculate arrays in their data source. This is particularly useful for things like "Top N" lists or fixed-size forms.
 **Pattern:** Use simple, numeric-to-collection transforms to bridge the gap between scalar data and structural document requirements (like row expansion).
+
+## 2025-05-21 - [Object Entry Transformation for Iteration]
+**Learning:** Enabling iteration over object properties is a common requirement for dynamic templates. By providing an `entries` transform that converts objects into a standardized `{ key, value }` array, we bridge the gap between static objects and the array-based row expansion engine.
+**Pattern:** Map native language structures (like `Object.entries`) into a format that fits the library's existing iteration patterns (array of objects), ensuring consistency between different data shapes and their visual representation in the document.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ After interpolation with the data above, the result would be:
 - **Type Preservation**: If the cell contains *only* the `{{key}}` marker, the resulting cell will have the same type as the data (e.g., Number, Date, Boolean).
 - Supports nested paths: `{{user.profile.email}}`.
 - **Default values**: `{{path || fallback}}`. Fallback can be a literal string or another path.
-- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`/`uppercase`, `lower`/`lowercase`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `join`, `unique`, `first`, `last`, `length`, `plural`, `round`, `floor`, `ceil`, `abs`, `range`, `reverse`, `sort`, `compact`, `sum`, `avg`, `min`, `max`, `year`, `month`, `day`, `hour`, `minute`, `second`, `weekday`, `empty`, `notempty`, `boolean`, `number`, `string`. You can chain them: `{{title | trim | capitalize}}`.
+- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`/`uppercase`, `lower`/`lowercase`, `capitalize`, `trim`, `trimstart`, `trimend`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `initials`, `json`, `join`, `unique`, `first`, `last`, `length`, `plural`, `round`, `floor`, `ceil`, `abs`, `range`, `reverse`, `sort`, `compact`, `sum`, `avg`, `min`, `max`, `year`, `month`, `day`, `hour`, `minute`, `second`, `weekday`, `empty`, `notempty`, `boolean`, `number`, `string`, `keys`, `values`, `entries`, `lines`, `flat`. You can chain them: `{{title | trim | capitalize}}`.
 - If the key is missing and no default is provided, the marker remains in the cell as-is.
 - If the value is `null` or `undefined` and no default is provided, the cell becomes empty (`""`).
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Used for static values that appear once in your document (e.g., a customer name,
 - **Nested Paths**: Supports dot notation like `{{user.profile.name}}`.
 - **Missing Data**: If a key is missing, the marker `{{key}}` stays in the cell for easier debugging.
 - **Null Values**: If a value is `null` or `undefined`, the cell is cleared.
-- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`, `lower`, `capitalize`, `trim`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `join`, `unique`, `first`, `last`, `length`, `plural`, `round`, `floor`, `ceil`, `abs`, `range`, `reverse`, `sort`, `compact`, `sum`, `avg`, `min`, `max`, `year`, `month`, `day`, `hour`, `minute`, `second`, `weekday`, `empty`, `notempty`, `boolean`, `number`, `string`. You can chain them: `{{title | trim | capitalize}}`.
+- **Transforms**: Use the pipe operator `|` to transform values: `{{name | upper}}`. Supported: `upper`, `lower`, `capitalize`, `trim`, `trimstart`, `trimend`, `camelCase`, `pascalCase`, `snakeCase`, `kebabCase`, `titleCase`, `initials`, `json`, `join`, `unique`, `first`, `last`, `length`, `plural`, `round`, `floor`, `ceil`, `abs`, `range`, `reverse`, `sort`, `compact`, `sum`, `avg`, `min`, `max`, `year`, `month`, `day`, `hour`, `minute`, `second`, `weekday`, `empty`, `notempty`, `boolean`, `number`, `string`, `keys`, `values`, `entries`, `lines`, `flat`. You can chain them: `{{title | trim | capitalize}}`.
 
 #### Array-Based Row Expansion: `[[array.key]]`
 Used to repeat an entire row for every item in an array.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -181,6 +181,18 @@ export function applyTransforms(value: any, transforms: string[]): any {
 					result = Object.values(result);
 				}
 				break;
+			case "entries":
+				if (
+					result != null &&
+					typeof result === "object" &&
+					!Array.isArray(result)
+				) {
+					result = Object.entries(result).map(([key, value]) => ({
+						key,
+						value,
+					}));
+				}
+				break;
 			case "flat":
 				if (Array.isArray(result)) {
 					result = result.flat();
@@ -277,13 +289,27 @@ export function applyTransforms(value: any, transforms: string[]): any {
 			case "string":
 				result = String(result);
 				break;
-			case "year": if (result instanceof Date) result = result.getUTCFullYear(); break;
-			case "month": if (result instanceof Date) result = result.getUTCMonth() + 1; break;
-			case "day": if (result instanceof Date) result = result.getUTCDate(); break;
-			case "hour": if (result instanceof Date) result = result.getUTCHours(); break;
-			case "minute": if (result instanceof Date) result = result.getUTCMinutes(); break;
-			case "second": if (result instanceof Date) result = result.getUTCSeconds(); break;
-			case "weekday": if (result instanceof Date) result = result.getUTCDay(); break;
+			case "year":
+				if (result instanceof Date) result = result.getUTCFullYear();
+				break;
+			case "month":
+				if (result instanceof Date) result = result.getUTCMonth() + 1;
+				break;
+			case "day":
+				if (result instanceof Date) result = result.getUTCDate();
+				break;
+			case "hour":
+				if (result instanceof Date) result = result.getUTCHours();
+				break;
+			case "minute":
+				if (result instanceof Date) result = result.getUTCMinutes();
+				break;
+			case "second":
+				if (result instanceof Date) result = result.getUTCSeconds();
+				break;
+			case "weekday":
+				if (result instanceof Date) result = result.getUTCDay();
+				break;
 		}
 	}
 	return result;

--- a/packages/core/tests/index.test.ts
+++ b/packages/core/tests/index.test.ts
@@ -171,6 +171,17 @@ describe("applyTransforms", () => {
 		expect(applyTransforms("not an object", ["values"])).toBe("not an object");
 	});
 
+	it("should handle entries transformation", () => {
+		expect(applyTransforms({ a: 1, b: 2 }, ["entries"])).toEqual([
+			{ key: "a", value: 1 },
+			{ key: "b", value: 2 },
+		]);
+		expect(applyTransforms({}, ["entries"])).toEqual([]);
+		expect(applyTransforms(["a", "b"], ["entries"])).toEqual(["a", "b"]); // should skip arrays
+		expect(applyTransforms("not an object", ["entries"])).toBe("not an object");
+		expect(applyTransforms(null, ["entries"])).toBeNull();
+	});
+
 	it("should handle flat transformation", () => {
 		expect(
 			applyTransforms(


### PR DESCRIPTION
💡 **What:** Added a new `entries` transform to the core library.
🎯 **Why:** Enables users to iterate over object properties using row expansion syntax, a common requirement for dynamic templates.
📦 **What it adds:** A new transformation case in `applyTransforms` that maps `Object.entries` to an array of `{ key, value }` objects.
🚀 **How to use:** `{{ myObject | entries }}` converts an object into an array suitable for `[[ ]]` expansion.
♻️ **Deps Free:** Uses only built-in JavaScript APIs.
🎨 **Harmony:** Follows existing transformation patterns and naming conventions.

---
*PR created automatically by Jules for task [10454181055268870167](https://jules.google.com/task/10454181055268870167) started by @galiprandi*